### PR TITLE
Fix app crashing due to an unnecessary call to recorder.delete()

### DIFF
--- a/app/src/main/java/app/musikus/services/RecorderService.kt
+++ b/app/src/main/java/app/musikus/services/RecorderService.kt
@@ -272,11 +272,6 @@ class RecorderService : Service() {
         }
     }
 
-    override fun onDestroy() {
-        recorder.delete()
-        super.onDestroy()
-    }
-
     private fun updateNotification(duration: Duration) {
         val notification: Notification = getNotification(duration)
         val mNotificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager


### PR DESCRIPTION
Closes #36 