### PR TITLE
chore: configure renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+
+    ":pinVersions",
+    ":rebaseStalePrs",
+
+    "group:all"
+  ],
+  "labels": ["dependencies"],
+  "automergeStrategy": "fast-forward",
+  "prConcurrentLimit": 1
+}


### PR DESCRIPTION
This adds a renovate config. For the bot to do its work, you will still need to add it to the repository: https://github.com/apps/renovate

The config will resolve to NOT automerge for now, but whenever you want to activate it, it will use fast-forward merges