### PR TITLE
Always scroll to top on new item added

### DIFF
--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
@@ -12,7 +12,6 @@
 package app.musikus.ui.activesession
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -450,7 +449,6 @@ private fun SectionsList(
     LaunchedEffect(key1 = uiState.sections) {
         snapshotFlow { listState.firstVisibleItemIndex }
             .collect {
-                Log.d("ActiveSession", "firstVisibleItemIndex: $it")
                 // Scroll to the top if a new item is added.
                 // (But only if user is scrolled to the top already.)
                 if (it <= 1 && listState.canScrollBackward) {

--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
@@ -75,7 +75,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -445,16 +447,13 @@ private fun SectionsList(
         }
     }
 
-    // scroll to top when new item is added https://stackoverflow.com/a/77690195
+    // scroll to top when new item is added
+    var sectionLen by remember { mutableIntStateOf(uiState.sections.size) }
     LaunchedEffect(key1 = uiState.sections) {
-        snapshotFlow { listState.firstVisibleItemIndex }
-            .collect {
-                // Scroll to the top if a new item is added.
-                // (But only if user is scrolled to the top already.)
-                if (it <= 1 && listState.canScrollBackward) {
-                    listState.animateScrollToItem(0)
-                }
-            }
+        if (uiState.sections.size > sectionLen && listState.canScrollBackward) {
+            listState.animateScrollToItem(0)
+        }
+        sectionLen = uiState.sections.size
     }
 }
 

--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
@@ -73,7 +73,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -438,7 +440,18 @@ private fun SectionsList(
                 onSectionDeleted = onSectionDeleted
             )
         }
+    }
 
+    // scroll to top when new item is added https://stackoverflow.com/a/77690195
+    LaunchedEffect(key1 = uiState.sections) {
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .collect {
+                // Scroll to the top if a new item is added.
+                // (But only if user is scrolled to the top already.)
+                if (it <= 1) {
+                    listState.animateScrollToItem(0)
+                }
+            }
     }
 }
 

--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
@@ -12,6 +12,7 @@
 package app.musikus.ui.activesession
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -449,9 +450,10 @@ private fun SectionsList(
     LaunchedEffect(key1 = uiState.sections) {
         snapshotFlow { listState.firstVisibleItemIndex }
             .collect {
+                Log.d("ActiveSession", "firstVisibleItemIndex: $it")
                 // Scroll to the top if a new item is added.
                 // (But only if user is scrolled to the top already.)
-                if (it <= 1) {
+                if (it <= 1 && listState.canScrollBackward) {
                     listState.animateScrollToItem(0)
                 }
             }

--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSession.kt
@@ -219,6 +219,9 @@ fun ActiveSession(
                 )
             }
 
+            /**
+             * --------------------- Dialogs ---------------------
+             */
 
             if (uiState.isPaused) {
                 PauseDialog(

--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSessionViewModel.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSessionViewModel.kt
@@ -62,7 +62,7 @@ data class EndDialogData(
 data class SessionViewModelState(
     val startTimestamp: ZonedDateTime,  // only needed for storing the session in the database
     val sessionDuration: Duration,
-    val sections: List<PracticeSection>,
+    val completedSections: List<PracticeSection>,
     val activeSection: Pair<LibraryItem, Duration>,
     val ongoingPauseDuration: Duration,
     val isPaused: Boolean
@@ -200,7 +200,7 @@ class ActiveSessionViewModel @Inject constructor(
         try {
             SessionViewModelState(
                 sessionDuration = activeSessionUseCases.getPracticeDuration(),
-                sections = completedSections,
+                completedSections = completedSections,
                 activeSection = Pair(runningItem, activeSessionUseCases.getRunningItemDuration()),
                 ongoingPauseDuration = activeSessionUseCases.getOngoingPauseDuration(),
                 isPaused = activeSessionUseCases.getPausedState(),
@@ -343,8 +343,8 @@ class ActiveSessionViewModel @Inject constructor(
             ongoingPauseDuration = sessionState?.ongoingPauseDuration ?: 0.seconds,
             isPaused = sessionState?.isPaused ?: false,
             addItemDialogUiState = addItemDialogUiState,
-            sections = sessionState?.sections?.reversed()?.map { section ->
-                    ActiveSessionSectionListItemUiState(
+            sections = sessionState?.completedSections?.reversed()?.map { section ->
+                ActiveSessionSectionListItemUiState(
                     id = section.id,
                     libraryItem = section.libraryItem,
                     duration = section.duration


### PR DESCRIPTION
fixes #55.

Lets the section list always scroll to top when adding a new item, but only if the user did not manually scroll down before.