### PR TITLE
Fix severe bug where all sections have the same start timestamp.

### DIFF
--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSessionViewModel.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSessionViewModel.kt
@@ -482,7 +482,7 @@ class ActiveSessionViewModel @Inject constructor(
                     SectionCreationAttributes(
                         libraryItemId = section.libraryItem.id,
                         duration = section.duration,
-                        startTimestamp = savableState.startTimestamp
+                        startTimestamp = section.startTimestamp
                     )
                 }
             )

--- a/app/src/main/java/app/musikus/usecase/activesession/GetFinalizedSessionUseCase.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/GetFinalizedSessionUseCase.kt
@@ -38,7 +38,8 @@ class GetFinalizedSessionUseCase(
             id = idProvider.generateId(),
             libraryItem = state.currentSectionItem,
             pauseDuration = state.startTimestampSectionPauseCompensated - state.startTimestampSection,
-            duration = runningSectionRoundedDuration
+            duration = runningSectionRoundedDuration,
+            startTimestamp = state.startTimestampSection
         )
 
         return state.copy(

--- a/app/src/main/java/app/musikus/usecase/activesession/SelectItemUseCase.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/SelectItemUseCase.kt
@@ -55,7 +55,8 @@ class SelectItemUseCase(
                 id = idProvider.generateId(),
                 libraryItem = state.currentSectionItem,
                 pauseDuration = state.startTimestampSectionPauseCompensated - state.startTimestampSection,
-                duration = runningSectionRoundedDuration
+                duration = runningSectionRoundedDuration,
+                startTimestamp = state.startTimestampSection
             )
             // adjust session state
             activeSessionRepository.setSessionState(

--- a/app/src/main/java/app/musikus/usecase/activesession/Types.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/Types.kt
@@ -29,7 +29,8 @@ data class PracticeSection(
     val id: UUID,
     val libraryItem: LibraryItem,
     val pauseDuration: Duration,   // set when section is completed
-    val duration: Duration         // set when section is completed
+    val duration: Duration,         // set when section is completed
+    val startTimestamp: ZonedDateTime
 )
 
 data class SessionState(


### PR DESCRIPTION
Fixes #67

The problem was that all sections were getting the same `startTimestamp` on save ([`Code`](https://github.com/matthiasemde/musikus-android/blob/2099b42c8fd2c1b6109c1d55f3b13b1de4f2b7b7/app/src/main/java/app/musikus/ui/activesession/ActiveSessionViewModel.kt#L485)). This lead to crashing `sections.single().startTimestamp` in `GetLastPracticedDateUseCase` because `single()` returned more than one Element.

During the refactor (#39) I forgot to include the `startTimestamp` inside of a `PracticeSection` and just used the `startTimestamp` of the whole Session (which was introduced by us and is not yet stored in the database) for each Section.

⚠️ However on release actually we **must** either catch this error or include a hook to "repair" the malicious database since even with this bugfix applied,  `GetLastPracticedDateUseCase` will crash if the user once trained one item within the same session since then. ⚠️