### PR TITLE
Simplify SessionService and bring back "Resume session"

### DIFF
--- a/app/src/androidTest/java/app/musikus/di/TestAppModule.kt
+++ b/app/src/androidTest/java/app/musikus/di/TestAppModule.kt
@@ -34,6 +34,7 @@ import app.musikus.usecase.activesession.GetRunningItemUseCase
 import app.musikus.usecase.activesession.GetRunningItemDurationUseCase
 import app.musikus.usecase.activesession.GetStartTimeUseCase
 import app.musikus.usecase.activesession.GetTotalPracticeDurationUseCase
+import app.musikus.usecase.activesession.IsSessionRunningUseCase
 import app.musikus.usecase.activesession.PauseActiveSessionUseCase
 import app.musikus.usecase.activesession.ResetSessionUseCase
 import app.musikus.usecase.activesession.ResumeActiveSessionUseCase
@@ -356,7 +357,8 @@ object TestAppModule {
             ),
             getStartTime = GetStartTimeUseCase(activeSessionRepository),
             reset = ResetSessionUseCase(activeSessionRepository),
-            getRunningItem = GetRunningItemUseCase(activeSessionRepository)
+            getRunningItem = GetRunningItemUseCase(activeSessionRepository),
+            isSessionRunning = IsSessionRunningUseCase(activeSessionRepository)
         )
     }
 

--- a/app/src/main/java/app/musikus/Application.kt
+++ b/app/src/main/java/app/musikus/Application.kt
@@ -47,7 +47,7 @@ class Musikus : Application() {
             val sessionNotificationChannel = NotificationChannel(
                 SESSION_NOTIFICATION_CHANNEL_ID,
                 SESSION_NOTIFICATION_CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_LOW).apply {
+                NotificationManager.IMPORTANCE_HIGH).apply {
                 description = "Notification to keep track of the running session"
             }
 

--- a/app/src/main/java/app/musikus/di/UseCasesModule.kt
+++ b/app/src/main/java/app/musikus/di/UseCasesModule.kt
@@ -18,10 +18,11 @@ import app.musikus.usecase.activesession.GetCompletedSectionsUseCase
 import app.musikus.usecase.activesession.GetFinalizedSessionUseCase
 import app.musikus.usecase.activesession.GetOngoingPauseDurationUseCase
 import app.musikus.usecase.activesession.GetPausedStateUseCase
-import app.musikus.usecase.activesession.GetRunningItemUseCase
 import app.musikus.usecase.activesession.GetRunningItemDurationUseCase
+import app.musikus.usecase.activesession.GetRunningItemUseCase
 import app.musikus.usecase.activesession.GetStartTimeUseCase
 import app.musikus.usecase.activesession.GetTotalPracticeDurationUseCase
+import app.musikus.usecase.activesession.IsSessionRunningUseCase
 import app.musikus.usecase.activesession.PauseActiveSessionUseCase
 import app.musikus.usecase.activesession.ResetSessionUseCase
 import app.musikus.usecase.activesession.ResumeActiveSessionUseCase
@@ -254,7 +255,8 @@ object UseCasesModule {
             ),
             getStartTime = GetStartTimeUseCase(activeSessionRepository),
             reset = ResetSessionUseCase(activeSessionRepository),
-            getRunningItem = GetRunningItemUseCase(activeSessionRepository)
+            getRunningItem = GetRunningItemUseCase(activeSessionRepository),
+            isSessionRunning = IsSessionRunningUseCase(activeSessionRepository)
         )
     }
 

--- a/app/src/main/java/app/musikus/repository/ActiveSessionRepository.kt
+++ b/app/src/main/java/app/musikus/repository/ActiveSessionRepository.kt
@@ -29,4 +29,8 @@ class ActiveSessionRepositoryImpl : ActiveSessionRepository {
     override fun reset() {
         sessionState.update { null }
     }
+
+    override fun isRunning(): Boolean {
+        return sessionState.value != null
+    }
 }

--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSessionUiState.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSessionUiState.kt
@@ -109,23 +109,15 @@ sealed class ActiveSessionUiEvent : DraggableCardUiEvent {
 
     data class SelectFolder(val folderId: UUID?) : ActiveSessionUiEvent()
     data class SelectItem(val item: LibraryItem) : ActiveSessionUiEvent()
-
     data class DeleteSection(val sectionId: UUID) : ActiveSessionUiEvent()
-
     data object BackPressed : ActiveSessionUiEvent()
-
     data object ShowDiscardSessionDialog : ActiveSessionUiEvent()
-
     data object DiscardSessionDialogConfirmed : ActiveSessionUiEvent()
     data object DiscardSessionDialogDismissed : ActiveSessionUiEvent()
-
     data object TogglePause : ActiveSessionUiEvent()
     data object ShowFinishDialog : ActiveSessionUiEvent()
-
     data object CreateNewLibraryItem : ActiveSessionUiEvent()
-
     data class ItemDialogUiEvent(val dialogEvent: LibraryItemDialogUiEvent) : ActiveSessionUiEvent()
-
     data class EndDialogRatingChanged(val rating: Int) : ActiveSessionUiEvent()
     data class EndDialogCommentChanged(val comment: String) : ActiveSessionUiEvent()
     data object EndDialogDismissed : ActiveSessionUiEvent()

--- a/app/src/main/java/app/musikus/ui/activesession/ActiveSessionViewModel.kt
+++ b/app/src/main/java/app/musikus/ui/activesession/ActiveSessionViewModel.kt
@@ -482,7 +482,7 @@ class ActiveSessionViewModel @Inject constructor(
                     SectionCreationAttributes(
                         libraryItemId = section.libraryItem.id,
                         duration = section.duration,
-                        startTimestamp = savableState.startTimestamp
+                        startTimestamp = section.startTimestamp
                     )
                 }
             )

--- a/app/src/main/java/app/musikus/ui/home/HomeScreen.kt
+++ b/app/src/main/java/app/musikus/ui/home/HomeScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -203,11 +205,17 @@ fun MusikusBottomBar(
                 }
                 NavigationBarItem(
                     icon = {
-                        Image(
-                            painter = if (selected) animatedPainters[activePainter] else painter,
-                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
-                            contentDescription = null
-                        )
+                        BadgedBox(badge = {
+                            if (tab == Screen.HomeTab.Sessions && mainUiState.isSessionRunning) {
+                                Badge()
+                            }
+                        }) {
+                            Image(
+                                painter = if (selected) animatedPainters[activePainter] else painter,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+                                contentDescription = null
+                            )
+                        }
                     },
                     label = {
                         Text(

--- a/app/src/main/java/app/musikus/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/app/musikus/ui/sessions/SessionsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -105,17 +106,26 @@ fun SessionsScreen(
         floatingActionButton = {
             ExtendedFloatingActionButton(
                 icon = {
-                    Icon(
-                        imageVector = Icons.Default.Add,
-                        contentDescription = "new session"
-                    )
+                    if(mainUiState.isSessionRunning) {
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowUp,
+                            contentDescription = "resume session"
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "new session"
+                        )
+                    }
                 },
                 text = {
-                    Text(text = "Start session")
+                    Text(text = if(mainUiState.isSessionRunning) "Resume session" else "Start session")
                 },
                 onClick = { navigateTo(Screen.ActiveSession) },
                 expanded = fabExpanded,
-                containerColor = MaterialTheme.colorScheme.primaryContainer
+                containerColor =
+                if (mainUiState.isSessionRunning) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.primaryContainer
             )
         },
         topBar = {

--- a/app/src/main/java/app/musikus/usecase/activesession/ActiveSessionUseCases.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/ActiveSessionUseCases.kt
@@ -23,4 +23,5 @@ data class ActiveSessionUseCases(
     val getStartTime: GetStartTimeUseCase,
     val getFinalizedSession: GetFinalizedSessionUseCase,
     val reset: ResetSessionUseCase,
+    val isSessionRunning: IsSessionRunningUseCase,
 )

--- a/app/src/main/java/app/musikus/usecase/activesession/GetFinalizedSessionUseCase.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/GetFinalizedSessionUseCase.kt
@@ -38,7 +38,8 @@ class GetFinalizedSessionUseCase(
             id = idProvider.generateId(),
             libraryItem = state.currentSectionItem,
             pauseDuration = state.startTimestampSectionPauseCompensated - state.startTimestampSection,
-            duration = runningSectionRoundedDuration
+            duration = runningSectionRoundedDuration,
+            startTimestamp = state.startTimestampSection
         )
 
         return state.copy(

--- a/app/src/main/java/app/musikus/usecase/activesession/IsSessionRunningUseCase.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/IsSessionRunningUseCase.kt
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2024 Michael Prommersberger
+ *
+ */
+
 package app.musikus.usecase.activesession
 
 class IsSessionRunningUseCase(

--- a/app/src/main/java/app/musikus/usecase/activesession/IsSessionRunningUseCase.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/IsSessionRunningUseCase.kt
@@ -1,0 +1,9 @@
+package app.musikus.usecase.activesession
+
+class IsSessionRunningUseCase(
+    private val activeSessionRepository: ActiveSessionRepository
+) {
+    operator fun invoke() : Boolean {
+        return activeSessionRepository.isRunning()
+    }
+}

--- a/app/src/main/java/app/musikus/usecase/activesession/SelectItemUseCase.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/SelectItemUseCase.kt
@@ -55,7 +55,8 @@ class SelectItemUseCase(
                 id = idProvider.generateId(),
                 libraryItem = state.currentSectionItem,
                 pauseDuration = state.startTimestampSectionPauseCompensated - state.startTimestampSection,
-                duration = runningSectionRoundedDuration
+                duration = runningSectionRoundedDuration,
+                startTimestamp = state.startTimestampSection
             )
             // adjust session state
             activeSessionRepository.setSessionState(

--- a/app/src/main/java/app/musikus/usecase/activesession/Types.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/Types.kt
@@ -23,6 +23,8 @@ interface ActiveSessionRepository {
     fun getSessionState() : Flow<SessionState?>
 
     fun reset()
+
+    fun isRunning(): Boolean
 }
 
 data class PracticeSection(

--- a/app/src/main/java/app/musikus/usecase/activesession/Types.kt
+++ b/app/src/main/java/app/musikus/usecase/activesession/Types.kt
@@ -29,7 +29,8 @@ data class PracticeSection(
     val id: UUID,
     val libraryItem: LibraryItem,
     val pauseDuration: Duration,   // set when section is completed
-    val duration: Duration         // set when section is completed
+    val duration: Duration,         // set when section is completed
+    val startTimestamp: ZonedDateTime
 )
 
 data class SessionState(


### PR DESCRIPTION
This PR completely removes the dependency of `SessionService` from `ActiveSession`. Since we have useCases for the ActiveSession there's acutally no need for bidirectional *synchronous* communication between `ActiveSessionViewModel` and `SessionService`[^1].
[^1]: I did [some research](https://stackoverflow.com/a/43993739) and came to the conclusion that using a Bound service brings no benefits rather than bloat to the code and redundancy / ambiguousness on how to interface with the service.

Therefore, all service binding and indirection to the service is removed and `ActiveSessionViewModel` is self-contained in managing an ActiveSession. The "interface" to the service is only via `Intent` (with two `ActiveSessionServiceActions`: `START` and `STOP`). All "logical" communication is done *asynchrounously* via the useCases.

Also, this was a great opportunity to fix the unintuitive notification behavior. Now:
* the notification is only shown when the app  is not visible. This is the same behavior as in other apps, e.g. the Google Clock app.
* the Channel priority is raised to `IMPORTANCE_HIGH` to show a Heads-Up notification when it starts and to show it in the lockscreen. **We should check if changing the Priority is possible via app upgrade though since I encountered inconsistent behavior after raising the priority. Maybe we will have to create a new channel / rename it**

Since `SessionService` 's only purpose is to display the notification it only lives as long as it shows a notification, i.e. only when the app is not visible. When the Service detects that the ActiveSession has stopped, it automatically terminates itself as well.

Also, via the useCases it was very easy to bring back "Resume Service" functionality and the Badge without any communication with the service itself (just by checking whether there is a running session). 

Also, I added `IsSessionRunningUseCase` for a convenient way to query whether a Session is active without a `suspend` call and without a using a `Flow` to be used easily in callback functions (timerTick, onPause, onResume,...)

This PR fixes #37.