### PR TITLE
feat: add automatic license reports and license screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     id("dagger.hilt.android.plugin")
     id("com.google.devtools.ksp")
     id("de.mannodermaus.android-junit5")
+    id("com.jaredsburrows.license")
 }
 
 android {

--- a/app/src/main/java/app/musikus/ui/Screen.kt
+++ b/app/src/main/java/app/musikus/ui/Screen.kt
@@ -92,6 +92,10 @@ sealed class Screen(
         route = "settings",
     )
 
+    data object License : Screen(
+        route = "settings/about/license"
+    )
+
     sealed class SettingsOption(
         subRoute: String,
         override val displayData: DisplayData

--- a/app/src/main/java/app/musikus/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/app/musikus/ui/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ import app.musikus.ui.components.TwoLiner
 import app.musikus.ui.components.TwoLinerData
 import app.musikus.ui.navigateTo
 import app.musikus.ui.settings.about.AboutScreen
+import app.musikus.ui.settings.about.LicenseScreen
 import app.musikus.ui.settings.appearance.AppearanceScreen
 import app.musikus.ui.settings.backup.BackupScreen
 import app.musikus.ui.settings.donate.DonateScreen
@@ -67,7 +68,13 @@ fun NavGraphBuilder.addSettingsNavigationGraph(navController: NavController) {
         HelpScreen(navigateUp = { navController.navigateUp() })
     }
     composable(Screen.SettingsOption.About.route) {
-        AboutScreen(navigateUp = { navController.navigateUp() })
+        AboutScreen(
+            navigateUp = { navController.navigateUp() },
+            navigateTo = navController::navigateTo
+        )
+    }
+    composable(Screen.License.route) {
+        LicenseScreen(navigateUp = { navController.navigateUp() })
     }
 }
 

--- a/app/src/main/java/app/musikus/ui/settings/about/AboutScreen.kt
+++ b/app/src/main/java/app/musikus/ui/settings/about/AboutScreen.kt
@@ -11,14 +11,12 @@ package app.musikus.ui.settings.about
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -26,21 +24,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.core.content.ContextCompat
 import app.musikus.BuildConfig
 import app.musikus.R
+import app.musikus.ui.Screen
 import app.musikus.ui.components.TwoLiner
 import app.musikus.ui.components.TwoLinerData
 import app.musikus.ui.theme.spacing
@@ -51,7 +43,8 @@ import app.musikus.utils.UiText
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AboutScreen(
-    navigateUp: () -> Unit
+    navigateUp: () -> Unit,
+    navigateTo: (Screen) -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -70,8 +63,6 @@ fun AboutScreen(
     ) { paddingValues ->
         val privacyPolicyUrl = stringResource(id = R.string.url_privacy)
         val context = LocalContext.current
-
-        var showLicenses by remember { mutableStateOf(false) }
 
         val aboutScreenItems = listOf(
             listOf(TwoLinerData(
@@ -100,7 +91,7 @@ fun AboutScreen(
                 ),
                 TwoLinerData(
                     firstLine = UiText.DynamicString("Licenses"),
-                    onClick = { showLicenses = true }
+                    onClick = { navigateTo(Screen.License) }
                 ),
                 TwoLinerData(
                     secondLine = UiText.DynamicString(
@@ -123,22 +114,6 @@ fun AboutScreen(
                 }
                 if (group != aboutScreenItems.last()) {
                     HorizontalDivider(Modifier.padding(vertical = MaterialTheme.spacing.medium))
-                }
-            }
-        }
-
-        if(showLicenses) {
-            Dialog(
-                onDismissRequest = { showLicenses = false },
-                properties = DialogProperties(dismissOnClickOutside = true)
-            ) {
-                Card(Modifier.fillMaxWidth()) {
-                    Column(Modifier.padding(MaterialTheme.spacing.medium)) {
-                        Text(text = "Licenses")
-                        TextButton(onClick = { showLicenses = false }) {
-                            Text(text = "Cancel")
-                        }
-                    }
                 }
             }
         }

--- a/app/src/main/java/app/musikus/ui/settings/about/LicenseScreen.kt
+++ b/app/src/main/java/app/musikus/ui/settings/about/LicenseScreen.kt
@@ -1,0 +1,77 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2024 Matthias Emde
+ */
+
+package app.musikus.ui.settings.about
+
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import app.musikus.R
+import app.musikus.ui.theme.spacing
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LicenseScreen(
+    navigateUp: () -> Unit
+) {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            TopAppBar(
+                scrollBehavior = scrollBehavior,
+                title = { Text("Licenses") },
+                navigationIcon = {
+                    IconButton(onClick = navigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        val licenses = LocalContext.current.resources.openRawResource(R.raw.third_party_licenses).bufferedReader().use {
+            it.readText().split("\n")
+        }
+
+        LazyColumn(
+            state = rememberLazyListState(),
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(horizontal = MaterialTheme.spacing.small)
+        ) {
+            licenses.forEach {
+                item{
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/raw/third_party_licenses
+++ b/app/src/main/res/raw/third_party_licenses
@@ -1,0 +1,323 @@
+The following dependencies are licensed under Apache License, Version 2.0:
+
+* Activity (https://developer.android.com/jetpack/androidx/releases/activity#1.7.1)
+* Activity Compose (https://developer.android.com/jetpack/androidx/releases/activity#1.7.1)
+* Activity Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/activity#1.7.1)
+* Android App Startup Runtime (https://developer.android.com/jetpack/androidx/releases/startup#1.1.1)
+* Android Arch-Common (https://developer.android.com/jetpack/androidx/releases/arch-core#2.2.0)
+* Android Arch-Runtime (https://developer.android.com/jetpack/androidx/releases/arch-core#2.2.0)
+* Android DataStore (https://developer.android.com/jetpack/androidx/releases/datastore#1.0.0)
+* Android DataStore Core (https://developer.android.com/jetpack/androidx/releases/datastore#1.0.0)
+* Android Emoji2 Compat (https://developer.android.com/jetpack/androidx/releases/emoji2#1.3.0)
+* Android Preferences DataStore (https://developer.android.com/jetpack/androidx/releases/datastore#1.0.0)
+* Android Preferences DataStore Core (https://developer.android.com/jetpack/androidx/releases/datastore#1.0.0)
+* Android Support ExifInterface (https://developer.android.com/jetpack/androidx/releases/exifinterface#1.3.6)
+* Android Support Library Async Layout Inflater (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library Coordinator Layout (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library core UI (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library core utils (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library Cursor Adapter (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library Custom View (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library Document File (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library Drawer Layout (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library fragment (https://developer.android.com/jetpack/androidx/releases/fragment#1.5.1)
+* Android Support Library Interpolators (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library loader (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library Local Broadcast Manager (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library Print (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library Sliding Pane Layout (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library v4 (http://developer.android.com/tools/extras/support-library.html)
+* Android Support Library View Pager (http://developer.android.com/tools/extras/support-library.html)
+* Android Tracing (https://developer.android.com/jetpack/androidx/releases/tracing#1.0.0)
+* AndroidX Autofill (https://developer.android.com/jetpack/androidx)
+* AndroidX Futures (https://developer.android.com/topic/libraries/architecture/index.html)
+* androidx.customview:poolingcontainer (https://developer.android.com/jetpack/androidx/releases/customview#1.0.0)
+* androidx.profileinstaller:profileinstaller (https://developer.android.com/jetpack/androidx/releases/profileinstaller#1.3.0)
+* Annotation (https://developer.android.com/jetpack/androidx/releases/annotation#1.7.0)
+* collections (https://developer.android.com/jetpack/androidx/releases/collection#1.4.0)
+* Collections Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/collection#1.4.0)
+* Compose Animation (https://developer.android.com/jetpack/androidx/releases/compose-animation#1.6.4)
+* Compose Animation Core (https://developer.android.com/jetpack/androidx/releases/compose-animation#1.6.4)
+* Compose Animation Graphics (https://developer.android.com/jetpack/androidx/releases/compose-animation#1.6.4)
+* Compose Foundation (https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.6.4)
+* Compose Geometry (https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.4)
+* Compose Graphics (https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.4)
+* Compose Layouts (https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.6.4)
+* Compose LiveData integration (https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.6.4)
+* Compose Material 3 Window Size Class (https://developer.android.com/jetpack/androidx/releases/compose-material3#1.2.1)
+* Compose Material Icons Core (https://developer.android.com/jetpack/androidx/releases/compose-material#1.6.4)
+* Compose Material Icons Extended (https://developer.android.com/jetpack/androidx/releases/compose-material#1.6.4)
+* Compose Material Ripple (https://developer.android.com/jetpack/androidx/releases/compose-material#1.6.4)
+* Compose Material3 Components (https://developer.android.com/jetpack/androidx/releases/compose-material3#1.2.1)
+* Compose Navigation (https://developer.android.com/jetpack/androidx/releases/navigation#2.7.7)
+* Compose Runtime (https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.6.4)
+* Compose Saveable (https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.6.4)
+* Compose UI (https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.4)
+* Compose UI Preview Tooling (https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.4)
+* Compose UI Text (https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.4)
+* Compose Unit (https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.4)
+* Compose Util (https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.4)
+* Core (https://developer.android.com/jetpack/androidx/releases/core#1.12.0)
+* Core Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/core#1.12.0)
+* Dagger (https://github.com/google/dagger)
+* Dagger Lint Rules AAR Distribution (https://github.com/google/dagger)
+* Experimental annotation (https://developer.android.com/jetpack/androidx/releases/annotation#1.4.0)
+* FindBugs-jsr305 (http://findbugs.sourceforge.net/)
+* Guava InternalFutureFailureAccess and InternalFutures
+* Guava ListenableFuture only
+* Guava: Google Core Libraries for Java (https://github.com/google/guava)
+* Hilt Android (https://github.com/google/dagger)
+* Hilt Core (https://github.com/google/dagger)
+* javax.inject (http://code.google.com/p/atinject/)
+* JetBrains Java Annotations (https://github.com/JetBrains/java-annotations)
+* Jetpack WindowManager Library (https://developer.android.com/jetpack/androidx/releases/window#1.0.0)
+* Kotlin Stdlib (https://kotlinlang.org/)
+* Kotlin Stdlib Jdk7 (https://kotlinlang.org/)
+* Kotlin Stdlib Jdk8 (https://kotlinlang.org/)
+* kotlinx-coroutines-android (https://github.com/Kotlin/kotlinx.coroutines)
+* kotlinx-coroutines-core (https://github.com/Kotlin/kotlinx.coroutines)
+* kotlinx-coroutines-swing (https://github.com/Kotlin/kotlinx.coroutines)
+* Lifecycle Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle LiveData (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle LiveData Core (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle Process (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle Runtime (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle Runtime Compose (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle ViewModel (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle ViewModel Compose (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle ViewModel Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle ViewModel with SavedState (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle-Common (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Lifecycle-Common for Java 8 (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* LiveData Core Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
+* Media (https://developer.android.com/jetpack/androidx/releases/media#1.7.0)
+* Media3 common module
+* Media3 Container module
+* Media3 database module
+* Media3 DataSource module
+* Media3 decoder module
+* Media3 ExoPlayer module
+* Media3 Extractor module
+* Media3 Session module
+* Navigation Common (https://developer.android.com/jetpack/androidx/releases/navigation#2.7.7)
+* Navigation Common Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/navigation#2.7.7)
+* Navigation Compose Hilt Integration (https://developer.android.com/jetpack/androidx/releases/hilt#1.2.0)
+* Navigation Hilt Extension (https://developer.android.com/jetpack/androidx/releases/hilt#1.2.0)
+* Navigation Runtime (https://developer.android.com/jetpack/androidx/releases/navigation#2.7.7)
+* Navigation Runtime Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/navigation#2.7.7)
+* Room Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/room#2.6.1)
+* Room-Common (https://developer.android.com/jetpack/androidx/releases/room#2.6.1)
+* Room-Runtime (https://developer.android.com/jetpack/androidx/releases/room#2.6.1)
+* Saved State (https://developer.android.com/jetpack/androidx/releases/savedstate#1.2.1)
+* SavedState Kotlin Extensions (https://developer.android.com/jetpack/androidx/releases/savedstate#1.2.1)
+* SQLite (https://developer.android.com/jetpack/androidx/releases/sqlite#2.4.0)
+* SQLite Framework Integration (https://developer.android.com/jetpack/androidx/releases/sqlite#2.4.0)
+* VersionedParcelable (http://developer.android.com/tools/extras/support-library.html)
+
+=========================================================================
+=========================================================================
+
+                             Apache License
+                       Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================
+=========================================================================

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.android.application") version "8.3.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.20" apply false
     id("com.google.devtools.ksp") version "1.9.20-1.0.14" apply false
+    id("com.jaredsburrows.license") version "0.9.7" apply false
 }
 
 buildscript {

--- a/tools/format_licenses.sh
+++ b/tools/format_licenses.sh
@@ -1,0 +1,1 @@
+grep -E ") - |http" app/build/reports/licenses/licenseReleaseReport.txt | sed 's/^ *//; s/ (.*//; s|\(http[^ ]*\)|(\1)|g' | sed ':a;N;$!ba;s/\n(http/ (http/g' | sed 's/^/* /' | awk '!seen[$0]++' > app/src/main/res/raw/third_party_licenses


### PR DESCRIPTION
Add 'com.jaredsburrows.license' dependency which includes gradle task 'licenseReleaseReport' for generating a report of all dependencies and their licenses.

Add tools/format_licenses.sh for converting the license report to a nicely formatted text.

Add LicenseScreen.kt to display the formatted license report.

Closes: #16 