### PR TITLE
fix: migrate to new `edgeToEdge` API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,7 +111,9 @@ dependencies {
     val kotlinCoroutineVersion = "1.7.3"
     val mockkVersion = "1.13.9"
     val media3Version = "1.3.0"
+    val activityVersion = "1.8.2"
 
+    implementation("androidx.activity:activity-ktx:$activityVersion")
 
     implementation("androidx.navigation:navigation-runtime-ktx:$navVersion")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")

--- a/app/src/main/java/app/musikus/ui/MainActivity.kt
+++ b/app/src/main/java/app/musikus/ui/MainActivity.kt
@@ -16,7 +16,6 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import app.musikus.Musikus
 import app.musikus.database.MusikusDatabase
 import app.musikus.services.ActiveSessionServiceActions
@@ -61,8 +60,6 @@ class MainActivity : PermissionCheckerActivity() {
             ImportDatabaseContract()
         ) { importDatabaseCallback(applicationContext, it) }
 
-        // enable Edge-to-Edge drawing with new API
-        enableEdgeToEdge()
         setContent {
             MusikusApp(timeProvider)
         }

--- a/app/src/main/java/app/musikus/ui/MainActivity.kt
+++ b/app/src/main/java/app/musikus/ui/MainActivity.kt
@@ -16,6 +16,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import app.musikus.Musikus
 import app.musikus.database.MusikusDatabase
 import app.musikus.services.ActiveSessionServiceActions
@@ -60,6 +61,8 @@ class MainActivity : PermissionCheckerActivity() {
             ImportDatabaseContract()
         ) { importDatabaseCallback(applicationContext, it) }
 
+        // enable Edge-to-Edge drawing with new API
+        enableEdgeToEdge()
         setContent {
             MusikusApp(timeProvider)
         }

--- a/app/src/main/java/app/musikus/ui/theme/Theme.kt
+++ b/app/src/main/java/app/musikus/ui/theme/Theme.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.Color
@@ -75,7 +75,7 @@ fun MusikusTheme(
 
     // enable Edge-to-Edge drawing with new API
     val context = LocalContext.current as ComponentActivity
-    DisposableEffect(key1 = theme) {
+    LaunchedEffect(key1 = theme) {
 
         val statusBarColorDarkTheme = android.graphics.Color.TRANSPARENT
         val statusBarColorLightTheme = android.graphics.Color.TRANSPARENT
@@ -103,7 +103,6 @@ fun MusikusTheme(
                     darkScrim = navBarColorLightThemeOldDevices
                 ),
         )
-        onDispose {  }
     }
 
     MaterialTheme(

--- a/app/src/main/java/app/musikus/ui/theme/Theme.kt
+++ b/app/src/main/java/app/musikus/ui/theme/Theme.kt
@@ -8,24 +8,18 @@
 
 package app.musikus.ui.theme
 
-import android.app.Activity
 import android.os.Build
-import android.view.WindowManager
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.core.view.WindowCompat
 import app.musikus.datastore.ColorSchemeSelections
 import app.musikus.datastore.ThemeSelections
 
@@ -71,49 +65,6 @@ fun MusikusTheme(
             } else {
                 if (useDarkTheme) DarkColorScheme else LightColorScheme
             }
-        }
-    }
-
-    // source: https://gist.github.com/Khazbs/1f1f1b5c05f45dbfa465f249b1e20506
-    // and https://stackoverflow.com/questions/65610216/how-to-change-statusbar-color-in-jetpack-compose
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                window.setDecorFitsSystemWindows(false)
-
-                // background extends behind status and nav bar (even 3 button nav bar)
-                window.setFlags(
-                    WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
-                    WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
-                )
-            } else {
-                WindowCompat.setDecorFitsSystemWindows(window, false)
-
-                // status bar icons can adapt to light/dark theme,
-                // so we can make the status bar transparent
-                window.statusBarColor = Color.Transparent.toArgb()
-
-                // navigation bar icons can only adapt to light theme for API >= 26 (O),
-                // otherwise we need to manually set the nav bar color to something dark
-                window.navigationBarColor = if(
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.O || useDarkTheme
-                ) {
-                    Color.Transparent.toArgb()
-                } else {
-                    LightColorScheme.inverseSurface.toArgb()
-                }
-            }
-
-            // make sure there is no black translucent overlay on the nav bar
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                window.isNavigationBarContrastEnforced = false
-            }
-
-            val insets = WindowCompat.getInsetsController(window, view)
-            insets.isAppearanceLightStatusBars = !useDarkTheme
-            insets.isAppearanceLightNavigationBars = !useDarkTheme // has no effect on API < 26
         }
     }
 

--- a/app/src/main/java/app/musikus/ui/theme/Theme.kt
+++ b/app/src/main/java/app/musikus/ui/theme/Theme.kt
@@ -9,14 +9,19 @@
 package app.musikus.ui.theme
 
 import android.os.Build
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -66,6 +71,39 @@ fun MusikusTheme(
                 if (useDarkTheme) DarkColorScheme else LightColorScheme
             }
         }
+    }
+
+    // enable Edge-to-Edge drawing with new API
+    val context = LocalContext.current as ComponentActivity
+    DisposableEffect(key1 = theme) {
+
+        val statusBarColorDarkTheme = android.graphics.Color.TRANSPARENT
+        val statusBarColorLightTheme = android.graphics.Color.TRANSPARENT
+        val statusBarColorLightThemeOldDevices = DarkColorScheme.surface.toArgb()
+
+        val navBarColorDarkTheme = android.graphics.Color.TRANSPARENT
+        val navBarColorLightTheme = android.graphics.Color.TRANSPARENT
+        val navBarColorLightThemeOldDevices = DarkColorScheme.surface.toArgb()
+
+        context.enableEdgeToEdge(
+            statusBarStyle = if (useDarkTheme)
+                SystemBarStyle.dark(
+                    scrim = statusBarColorDarkTheme
+                )
+                else SystemBarStyle.light(
+                    scrim = statusBarColorLightTheme,
+                    darkScrim = statusBarColorLightThemeOldDevices
+                ),
+            navigationBarStyle = if (useDarkTheme)
+                SystemBarStyle.dark(
+                    scrim = navBarColorDarkTheme
+                )
+                else SystemBarStyle.light(
+                    scrim = navBarColorLightTheme,
+                    darkScrim = navBarColorLightThemeOldDevices
+                ),
+        )
+        onDispose {  }
     }
 
     MaterialTheme(


### PR DESCRIPTION
This PR makes use of the new [`edgeToEdge`](https://developer.android.com/develop/ui/views/layout/edge-to-edge) API [Google introduced in October](https://developer.android.com/jetpack/androidx/releases/activity#1.8.0) to finally fix the mess about inconsistent behavior when drawing content behind the navigation and status bar. [Here](https://dkexception.medium.com/beyond-the-frame-full-screen-apps-with-androids-edge-to-edge-api-dd28dec167a7) is also a nice article about it.

**No more API checks, no more edge-case<sup>pun intended!</sup> UI bugs!**

The API is as simple as calling `enableEdgeToEdge()` with optional parameters for [`SystemBarStyle`s](https://developer.android.com/reference/androidx/activity/SystemBarStyle). This also considers old APIs where there only exist a dark theme for the navigation bar (a.k.a. only white buttons are rendered).

Although [the documentation](https://developer.android.com/develop/ui/compose/layouts/insets#compose-apis) suggests calling `enableEdgeToEdge` directly in `onCreate()` of the `ComponentActivity`, we call it while setting the theme inside `Theme.kt` with a [`DisposableEffect`](https://developer.android.com/develop/ui/compose/side-effects#disposableeffect) (like it is done in [this article](https://medium.com/@shubhgajjar2004/different-ways-to-change-the-color-of-status-bar-and-navigation-bar-in-android-jetpack-compose-edd1c5542257)), because we need to know the currently selected theme for that.

Since `enableEdgeToEdge()` takes in `SystemBarStyle`s, we do not need to use the `activity.window` API for that anymore (refer to [above link](https://medium.com/@shubhgajjar2004/different-ways-to-change-the-color-of-status-bar-and-navigation-bar-in-android-jetpack-compose-edd1c5542257)) but instead directly pass in the `SystemBarStyles`.
