### PR TITLE
docs: add Google Play badge to README.md and remove contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Your personal practice companion
 </p>
 
 <br/>
+
+<p align="center">
+<a href='https://play.google.com/store/apps/details?id=app.musikus&hl=de&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
+  <img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png'height="70"/>
+</a>
+</p>
+
 <div align="center">
   <a href="https://github.com/matthiasemde/musikus-android/actions/workflows/ci.yml"><img src="https://github.com/matthiasemde/musikus-android/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/matthiasemde/musikus-android/releases/latest"><img src="https://img.shields.io/github/v/release/matthiasemde/musikus-android" alt="release"></a>
@@ -18,18 +25,18 @@ Your personal practice companion
 </div>
 <br/>
 
+
 ## 🧪 Musikus is in alpha
 
 ### Join
-If you want to join our group of testers, write us an email to [alpha@musikus.app](mailto:alpha@musikus.app) using your Gmail-account and we will add you to the list.
+
+If you want to join our group of testers, write us an email to [alpha@musikus.app](mailto:alpha@musikus.app) using your Google account and we will add you to the list. If you are amongst the list of testers, the badge above will bring you to the Play Store listing.
+Alternatively, you can always download the latest release [from GitHub](https://github.com/matthiasemde/musikus-android/releases/latest).
 
 ### Feedback
-If you have any feedback, bug reports or feature requests, please fill out [this](https://docs.google.com/forms/d/e/1FAIpQLSfw1rTslL7b3Yp_Lv_E65zketfj7G6h5VzOkVdxjcQZDC5CqA/viewform) form or use the [Issue Tracker](https://github.com/matthiasemde/musikus-android/issues/new).
 
-## 👨‍💻 Contributors
-<a href="https://github.com/matthiasemde/musikus-android/graphs/contributors">
-  <img width="140" src="https://contrib.rocks/image?repo=matthiasemde/musikus-android" alt="https://github.com/matthiasemde/musikus-android/graphs/contributors"/>
-</a>
+If you have any feedback, bug reports or feature requests, please fill out [this](https://docs.google.com/forms/d/e/1FAIpQLSfw1rTslL7b3Yp_Lv_E65zketfj7G6h5VzOkVdxjcQZDC5CqA/viewform) form or use the [Issue Tracker](https://github.com/matthiasemde/musikus-android/issues/new). We are always happy about ideas and feedback!
+
 
 ## 📃 License
 Copyright (c) Matthias Emde <br/>


### PR DESCRIPTION
I improved our README a bit: I added a Google Play badge and removed the Contributors section for now since it is visible anyways on the sidebar of the repository in an equal fashion