### PR TITLE
fix: improve TimeProvider and fix formatting for durations between one and two days

### DIFF
--- a/app/src/main/java/app/musikus/ui/goals/GoalCard.kt
+++ b/app/src/main/java/app/musikus/ui/goals/GoalCard.kt
@@ -192,7 +192,7 @@ fun GoalCard(
                                 modifier = Modifier.padding(horizontal = 16.dp),
                                 text = getDurationString(
                                     animatedProgress.toInt().seconds,
-                                    DurationFormat.HUMAN_PRETTY
+                                    DurationFormat.HM_DIGITAL_OR_MIN_HUMAN
                                 ),
                                 style = MaterialTheme.typography.titleMedium.copy(
                                     color = MaterialTheme.colorScheme.onSurface
@@ -202,7 +202,7 @@ fun GoalCard(
                                 modifier = Modifier.padding(horizontal = 16.dp),
                                 text = getDurationString(
                                     animatedProgressLeft.toInt().seconds,
-                                    DurationFormat.HUMAN_PRETTY
+                                    DurationFormat.HM_DIGITAL_OR_MIN_HUMAN
                                 ),
                                 style = MaterialTheme.typography.titleMedium.copy(
                                     color = MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/app/musikus/ui/statistics/sessionstatistics/SessionStatisticsViewModel.kt
+++ b/app/src/main/java/app/musikus/ui/statistics/sessionstatistics/SessionStatisticsViewModel.kt
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023 Matthias Emde
+ * Copyright (c) 2023-2024 Matthias Emde
  */
 
 package app.musikus.ui.statistics.sessionstatistics
@@ -168,11 +168,11 @@ class SessionStatisticsViewModel @Inject constructor(
             SessionStatisticsTab.DEFAULT,
             when(SessionStatisticsTab.DEFAULT) {
                 SessionStatisticsTab.DAYS ->
-                    timeProvider.getStartOfDay(dayOffset = -6) to timeProvider.getEndOfDay()
+                    timeProvider.getStartOfDay().minusDays(6) to timeProvider.getEndOfDay()
                 SessionStatisticsTab.WEEKS ->
-                    timeProvider.getStartOfWeek(weekOffset = -6) to timeProvider.getEndOfWeek()
+                    timeProvider.getStartOfWeek().minusWeeks(6) to timeProvider.getEndOfWeek()
                 SessionStatisticsTab.MONTHS ->
-                    timeProvider.getStartOfMonth(monthOffset = -6) to timeProvider.getEndOfMonth()
+                    timeProvider.getStartOfMonth().minusMonths(6) to timeProvider.getEndOfMonth()
             }
         ),
     )
@@ -275,14 +275,14 @@ class SessionStatisticsViewModel @Inject constructor(
         val timeframes = (0L..6L).reversed().map {
             when(selectedTab) {
                 SessionStatisticsTab.DAYS ->
-                    timeProvider.getStartOfDay(dayOffset = -it, dateTime = timeframeEnd.minusSeconds(1)) to
-                    timeProvider.getEndOfDay(dayOffset = -it, dateTime = timeframeEnd.minusSeconds(1))
+                    timeProvider.getStartOfDay(dateTime = timeframeEnd.minusSeconds(1)).minusDays(it) to
+                    timeProvider.getEndOfDay(dateTime = timeframeEnd.minusSeconds(1)).minusDays(it)
                 SessionStatisticsTab.WEEKS ->
-                    timeProvider.getStartOfWeek(weekOffset = -it, dateTime = timeframeEnd.minusSeconds(1)) to
-                    timeProvider.getEndOfWeek(weekOffset = -it, dateTime = timeframeEnd.minusSeconds(1))
+                    timeProvider.getStartOfWeek(dateTime = timeframeEnd.minusSeconds(1)).minusWeeks(it) to
+                    timeProvider.getEndOfWeek(dateTime = timeframeEnd.minusSeconds(1)).minusWeeks(it)
                 SessionStatisticsTab.MONTHS ->
-                    timeProvider.getStartOfMonth(monthOffset = -it, dateTime = timeframeEnd.minusSeconds(1)) to
-                    timeProvider.getEndOfMonth(monthOffset = -it, dateTime = timeframeEnd.minusSeconds(1))
+                    timeProvider.getStartOfMonth(dateTime = timeframeEnd.minusSeconds(1)).minusMonths(it) to
+                    timeProvider.getEndOfMonth(dateTime = timeframeEnd.minusSeconds(1)).minusMonths(it)
             }
         }
 
@@ -545,7 +545,7 @@ class SessionStatisticsViewModel @Inject constructor(
                         if (newEnd > endOfToday) {
                             newEnd = endOfToday
                         }
-                        timeProvider.getStartOfDay(dayOffset = -6, dateTime = newEnd.minusSeconds(1)) to newEnd
+                        timeProvider.getStartOfDay(dateTime = newEnd.minusSeconds(1)).minusDays(6) to newEnd
                     }
                     SessionStatisticsTab.WEEKS -> {
                         val endOfThisWeek = timeProvider.getEndOfWeek()
@@ -553,7 +553,7 @@ class SessionStatisticsViewModel @Inject constructor(
                         if (newEnd > endOfThisWeek) {
                             newEnd = endOfThisWeek
                         }
-                        timeProvider.getStartOfWeek(weekOffset = -6, dateTime = newEnd.minusSeconds(1)) to newEnd
+                        timeProvider.getStartOfWeek(dateTime = newEnd.minusSeconds(1)).minusWeeks(6) to newEnd
                     }
                     SessionStatisticsTab.MONTHS -> {
                         val endOfThisMonth = timeProvider.getEndOfMonth()
@@ -561,7 +561,7 @@ class SessionStatisticsViewModel @Inject constructor(
                         if (newEnd > endOfThisMonth) {
                             newEnd = endOfThisMonth
                         }
-                        timeProvider.getStartOfMonth(monthOffset = -6, dateTime = newEnd.minusSeconds(1)) to newEnd
+                        timeProvider.getStartOfMonth(dateTime = newEnd.minusSeconds(1)).minusMonths(6) to newEnd
                     }
                 }
             )
@@ -581,7 +581,7 @@ class SessionStatisticsViewModel @Inject constructor(
                         if(newEnd > endOfToday) {
                            newEnd = endOfToday
                         }
-                        timeProvider.getStartOfDay(dayOffset = -6, dateTime = newEnd.minusSeconds(1)) to newEnd
+                        timeProvider.getStartOfDay(dateTime = newEnd.minusSeconds(1)).minusDays(6) to newEnd
                     }
                     SessionStatisticsTab.WEEKS -> {
                         val endOfThisWeek = timeProvider.getEndOfWeek()
@@ -589,7 +589,7 @@ class SessionStatisticsViewModel @Inject constructor(
                         if(newEnd > endOfThisWeek) {
                            newEnd = endOfThisWeek
                         }
-                        timeProvider.getStartOfWeek(weekOffset = -6, dateTime = newEnd.minusSeconds(1)) to newEnd
+                        timeProvider.getStartOfWeek(dateTime = newEnd.minusSeconds(1)).minusWeeks(6) to newEnd
                     }
                     SessionStatisticsTab.MONTHS -> {
                         val endOfThisMonth = timeProvider.getEndOfMonth()
@@ -597,7 +597,7 @@ class SessionStatisticsViewModel @Inject constructor(
                         if(newEnd > endOfThisMonth) {
                            newEnd = endOfThisMonth
                         }
-                        timeProvider.getStartOfMonth(monthOffset = -6, dateTime = newEnd.minusSeconds(1)) to newEnd
+                        timeProvider.getStartOfMonth(dateTime = newEnd.minusSeconds(1)).minusMonths(6) to newEnd
                     }
                 }
             )
@@ -616,21 +616,21 @@ class SessionStatisticsViewModel @Inject constructor(
                         if(newStart < release) {
                             newStart = release
                         }
-                        newStart to timeProvider.getEndOfDay(dayOffset = 6, dateTime = newStart)
+                        newStart to timeProvider.getEndOfDay(dateTime = newStart).plusDays(6)
                     }
                     SessionStatisticsTab.WEEKS -> {
                         var newStart = start.minusWeeks(7)
                         if(newStart < release) {
                             newStart = release
                         }
-                        newStart to timeProvider.getEndOfWeek(weekOffset = 6, dateTime = newStart)
+                        newStart to timeProvider.getEndOfWeek(dateTime = newStart).plusWeeks(6)
                     }
                     SessionStatisticsTab.MONTHS -> {
                         var newStart = start.minusMonths(7)
                         if(newStart < release) {
                             newStart = release
                         }
-                        newStart to timeProvider.getEndOfMonth(monthOffset = 6, dateTime = newStart)
+                        newStart to timeProvider.getEndOfMonth(dateTime = newStart).plusMonths(6)
                     }
                 }
             )

--- a/app/src/main/java/app/musikus/utils/DurationFormatter.kt
+++ b/app/src/main/java/app/musikus/utils/DurationFormatter.kt
@@ -102,15 +102,15 @@ fun getDurationString(
                     }
                 }
 
-                if (minutes > 0) {
+                if (minutes > 0 || duration == 0.seconds) {
                     append("$spaceOrNot$minutes")
                     withStyle(SpanStyle(fontSize = SCALE_FACTOR_FOR_SMALL_TEXT.em)) {
                         append("m")
                     }
                 }
 
-                if(totalHours == 0L && minutes == 0L) {
-                    append("<" + spaceOrNot + "1")
+                if(duration < 1.minutes && duration > 0.seconds) {
+                    append("<${spaceOrNot}1")
                     withStyle(SpanStyle(fontSize = SCALE_FACTOR_FOR_SMALL_TEXT.em)) {
                         append("m")
                     }
@@ -147,15 +147,16 @@ fun getDurationString(
                 append(when {
                     totalHours > 0 -> "%02d:%02d".format(totalHours, minutes)
                     minutes > 0 -> "%d min".format(minutes)
-                    else -> "< 1min"
+                    seconds > 0 -> "< 1min"
+                    else -> "0 min"
                 })
             }
             DurationFormat.PRETTY_APPROX -> {
                 append(when {
                     // if time left is larger than a day, show the number of begun days
-                    days > 1 -> "${days + 1} days"
-                    // if days are zero, but hours is larger than 1 show the number of begun hours
-                    hours > 1 -> "${hours + 1} hours"
+                    days > 0 -> "${days + 1} days"
+                    // if days are zero, but hours is larger than 1, show the number of begun hours
+                    hours > 0 -> "${hours + 1} hours"
                     // else, show the number of begun minutes
                     else -> "${minutes + 1} minutes"
                 })
@@ -164,9 +165,9 @@ fun getDurationString(
             DurationFormat.PRETTY_APPROX_SHORT -> {
                 append(when {
                     // if time left is larger than a day, show the number of begun days
-                    days > 1 -> "${days + 1} days"
-                    // show the number of begun hours
-                    hours > 1 -> "${hours + 1}h"
+                    days > 0 -> "${days + 1} days"
+                    // if days are zero, but hours is larger than 1, show the number of begun hours
+                    hours > 0 -> "${hours + 1}h"
                     // else, show the number of begun minutes
                     else -> "${minutes + 1}m"
                 })

--- a/app/src/main/java/app/musikus/utils/PrepopulateDatabase.kt
+++ b/app/src/main/java/app/musikus/utils/PrepopulateDatabase.kt
@@ -102,21 +102,19 @@ suspend fun prepopulateDatabase(
                 periodUnit = GoalPeriodUnit.WEEK,
             ),
         ).forEach { goalDescriptionCreationAttributes ->
+            val offset = (
+                if (goalDescriptionCreationAttributes.repeat) 10L
+                else 1L
+            ) * goalDescriptionCreationAttributes.periodInPeriodUnits
+
             database.goalDescriptionDao.insert(
                 descriptionCreationAttributes = goalDescriptionCreationAttributes,
                 instanceCreationAttributes = GoalInstanceCreationAttributes(
-                    startTimestamp = database.timeProvider.getStartOfDay().minusDays(
-                        -1 *
-                            (
-                                if (goalDescriptionCreationAttributes.repeat) 10L
-                                else 1L
-                            ) * goalDescriptionCreationAttributes.periodInPeriodUnits
-                            * when(goalDescriptionCreationAttributes.periodUnit) {
-                                GoalPeriodUnit.DAY -> 1
-                                GoalPeriodUnit.WEEK -> 7
-                                GoalPeriodUnit.MONTH -> 31
-                            }
-                    ),
+                    startTimestamp = when(goalDescriptionCreationAttributes.periodUnit) {
+                        GoalPeriodUnit.DAY -> database.timeProvider.getStartOfDay().minusDays(offset)
+                        GoalPeriodUnit.WEEK -> database.timeProvider.getStartOfWeek().minusWeeks(offset)
+                        GoalPeriodUnit.MONTH -> database.timeProvider.getStartOfMonth().minusMonths(offset)
+                    },
                     target =((1..6).random() * 10 + 30).minutes
                 ),
                 libraryItemIds =

--- a/app/src/main/java/app/musikus/utils/PrepopulateDatabase.kt
+++ b/app/src/main/java/app/musikus/utils/PrepopulateDatabase.kt
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023 Matthias Emde
+ * Copyright (c) 2023-2024 Matthias Emde
  */
 
 package app.musikus.utils
@@ -105,8 +105,8 @@ suspend fun prepopulateDatabase(
             database.goalDescriptionDao.insert(
                 descriptionCreationAttributes = goalDescriptionCreationAttributes,
                 instanceCreationAttributes = GoalInstanceCreationAttributes(
-                    startTimestamp = database.timeProvider.getStartOfDay(
-                        dayOffset = -1 *
+                    startTimestamp = database.timeProvider.getStartOfDay().minusDays(
+                        -1 *
                             (
                                 if (goalDescriptionCreationAttributes.repeat) 10L
                                 else 1L

--- a/app/src/main/java/app/musikus/utils/TimeProvider.kt
+++ b/app/src/main/java/app/musikus/utils/TimeProvider.kt
@@ -24,104 +24,75 @@ interface TimeProvider {
     fun localZoneId(): ZoneId = now().zone
 
     /**
-     * Get the Beginning of dayOffset Days from now. dayOffset>0 -> future, dayOffset<0 -> past
+     * Get the beginning of current day.
      */
     fun getStartOfDay(
-        dayOffset: Long = 0,
-        weekOffset: Long = 0,
-        monthOffset: Long = 0,
         dateTime: ZonedDateTime = now()
-    ): ZonedDateTime = dateTime
-        .with(ChronoField.MILLI_OF_DAY, 0)
-        .toLocalDate()
-        .atStartOfDay(dateTime.zone)  // make sure time is 00:00
-        .plusMonths(monthOffset)
-        .plusWeeks(weekOffset)
-        .plusDays(dayOffset)
+    ): ZonedDateTime = dateTime.with(ChronoField.NANO_OF_DAY, 0)
 
     /**
-     * Get the End of dayOffset Days from now. Half-open: Actually get the Start of the Next day
+     * Get the end of day. Half-open: Actually get the start of the next day.
      */
     fun getEndOfDay(
-        dayOffset: Long = 0,
-        weekOffset: Long = 0,
-        monthOffset: Long = 0,
         dateTime: ZonedDateTime = now()
-    ) = getStartOfDay(dayOffset + 1, weekOffset, monthOffset, dateTime)
+    ): ZonedDateTime = getStartOfDay(dateTime).plusDays(1)
 
     /**
-     * get the Beginning of a Day (1=Mo, 7=Sun) of the current week (weekOffset=0) / the weeks before (weekOffset<0)
+     * Get the beginning of a day (1=Mo, 7=Sun) of the current week (datetime).
      */
     fun getStartOfDayOfWeek(
-        dayIndex: Long = 0,
-        weekOffset: Long,
-        dateTime: ZonedDateTime = now()
-    ): ZonedDateTime = dateTime
-        .with(ChronoField.SECOND_OF_DAY, 0)
-        .with(ChronoField.DAY_OF_WEEK , dayIndex )         // ISO 8601, Monday is first day of week.
-        .toLocalDate()
-        .atStartOfDay(dateTime.zone)  // make sure time is 00:00
-        .plusWeeks(weekOffset)
-
-    /**
-     * get the End of a Day (1=Mo, 7=Sun) of the current week (weekOffset=0) / the weeks before (weekOffset<0)
-     */
-    fun getEndOfDayOfWeek(
         dayIndex: Long,
-        weekOffset: Long,
         dateTime: ZonedDateTime = now()
     ): ZonedDateTime {
-        // because of half-open approach we have to get the "start of the _next_ day" instead of the end of the current day
-        // e.g. end of Tuesday = Start of Wednesday, so make dayIndex 2 -> 3
-        var nextDay = dayIndex + 1
-        var weekOffsetAdapted = weekOffset
-        if (dayIndex > 6) {
-            nextDay = (dayIndex + 1) % 7
-            weekOffsetAdapted += 1  // increase weekOffset so that we take the start of the first day of NEXT week as end of day
-        }
-        return getStartOfDayOfWeek(nextDay, weekOffsetAdapted, dateTime)
+        assert(dayIndex in 1..7)
+
+        return dateTime
+            .with(ChronoField.NANO_OF_DAY, 0)
+            .with(ChronoField.DAY_OF_WEEK , dayIndex) // ISO 8601, Monday is first day of week.
     }
 
     /**
-     * gets start date of a Week
+     * Get the end of a day (1=Mo, 7=Sun) of the current week (datetime).
+     * Half-open: Actually get the start of the next day.
      */
-    fun getStartOfWeek(
-        weekOffset: Long = 0,
+    fun getEndOfDayOfWeek(
+        dayIndex: Long,
         dateTime: ZonedDateTime = now()
-    ) = getStartOfDayOfWeek(1, weekOffset, dateTime)
+    ): ZonedDateTime {
+        assert(dayIndex in 1..7)
 
-
+        return getStartOfDayOfWeek(dayIndex, dateTime).plusDays(1)
+    }
 
     /**
-     * gets end date of a Week
+     * Get start date of a week
+     */
+    fun getStartOfWeek(
+        dateTime: ZonedDateTime = now()
+    ) = getStartOfDayOfWeek(1, dateTime)
+
+    /**
+     * Get end date of a week. Half-open: Actually get the start of the next week.
      */
     fun getEndOfWeek(
-        weekOffset: Long = 0,
         dateTime: ZonedDateTime = now()
-    ) = getEndOfDayOfWeek(7, weekOffset, dateTime)
-
+    ): ZonedDateTime = getStartOfWeek(dateTime).plusWeeks(1)
 
     /**
      * Get the start of a month.
-     * monthOffset=0 ->, monthOffset=1 -> next month, monthOffset = -1 -> last month, etc.
      */
     fun getStartOfMonth(
-        monthOffset: Long = 0,
         dateTime: ZonedDateTime = now()
     ): ZonedDateTime = dateTime
-        .with(ChronoField.SECOND_OF_DAY, 0)
-        .with(ChronoField.DAY_OF_MONTH , 1 )    // jump to first day of this month
-        .toLocalDate()
-        .atStartOfDay(dateTime.zone)  // make sure time is 00:00
-        .plusMonths(monthOffset) // add desired number of months from now
+        .with(ChronoField.NANO_OF_DAY, 0)
+        .with(ChronoField.DAY_OF_MONTH , 1 ) // jump to first day of this month
 
     /**
-     * Get the end of a month. Half-open: Actually get the Start of the next month.
+     * Get the end of a month. Half-open: Actually get the start of the next month.
      */
     fun getEndOfMonth(
-        monthOffset: Long = 0,
         dateTime: ZonedDateTime = now()
-    ) = getStartOfMonth(monthOffset + 1, dateTime)
+    ): ZonedDateTime = getStartOfMonth(dateTime).plusMonths(1)
 
     companion object {
         val uninitializedDateTime: ZonedDateTime =

--- a/app/src/test/java/app/musikus/utils/TimeProviderTest.kt
+++ b/app/src/test/java/app/musikus/utils/TimeProviderTest.kt
@@ -9,18 +9,24 @@
 package app.musikus.utils
 
 import com.google.common.truth.Truth.assertThat
+import io.mockk.spyk
+import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.ZonedDateTime
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 
 class TimeProviderTest {
 
+    private lateinit var timeProvider: FakeTimeProvider
+    private lateinit var timeProviderSpy: FakeTimeProvider
 
     @BeforeEach
     fun setUp() {
-
+        timeProvider = FakeTimeProvider()
+        timeProviderSpy = spyk(timeProvider)
     }
 
     @Test
@@ -45,5 +51,115 @@ class TimeProviderTest {
         val end = ZonedDateTime.parse("2021-01-01T00:00:00.050+01:00[Europe/Berlin]")
         val duration = end - start
         assertThat(duration).isEqualTo(50.milliseconds)
+    }
+
+
+    /** -------------- Get start/end of day -------------------- */
+    @Test
+    fun `Get start of day`() {
+        val startOfDay = timeProvider.getStartOfDay()
+        assertThat(startOfDay).isEqualTo(ZonedDateTime.parse("1969-07-20T00:00:00Z[UTC]"))
+    }
+
+    @Test
+    fun `Get start of day for specific datetime`() {
+        val startOfDay = timeProvider.getStartOfDay(
+            dateTime = ZonedDateTime.parse("1968-12-24T08:59:52Z[UTC]")
+        )
+        assertThat(startOfDay).isEqualTo(ZonedDateTime.parse("1968-12-24T00:00:00Z[UTC]"))
+    }
+
+    @Test
+    fun `Get end of day`() {
+        val endOfDay = timeProvider.getEndOfDay()
+        assertThat(endOfDay).isEqualTo(ZonedDateTime.parse("1969-07-21T00:00:00Z[UTC]"))
+    }
+
+    @Test
+    fun `Get end of day for specific datetime`() {
+        val endOfDay = timeProvider.getEndOfDay(
+            dateTime = ZonedDateTime.parse("1968-12-24T08:59:52Z[UTC]")
+        )
+        assertThat(endOfDay).isEqualTo(ZonedDateTime.parse("1968-12-25T00:00:00Z[UTC]"))
+    }
+
+
+    /** ----------- Get start/end of day of week ---------------- */
+
+    @Test
+    fun `Get start of day of week for monday`() {
+        val startOfDayOfWeek = timeProvider.getStartOfDayOfWeek(1)
+        assertThat(startOfDayOfWeek).isEqualTo(ZonedDateTime.parse("1969-07-14T00:00:00Z[UTC]"))
+    }
+
+    @Test
+    fun `Get start of day of week for sunday`() {
+        val startOfDayOfWeek = timeProvider.getStartOfDayOfWeek(7)
+        assertThat(startOfDayOfWeek).isEqualTo(ZonedDateTime.parse("1969-07-20T00:00:00Z[UTC]"))
+    }
+
+    @Test
+    fun `Get start of day of week for day index 8, throws assertion error`() {
+        assertThrows<AssertionError> {
+            timeProvider.getStartOfDayOfWeek(8)
+        }
+    }
+
+    @Test
+    fun `Get end of day of week for monday`() {
+        val endOfDayOfWeek = timeProvider.getEndOfDayOfWeek(
+            7,
+            ZonedDateTime.parse("1961-05-05T09:50:00Z[UTC]")
+        )
+        assertThat(endOfDayOfWeek).isEqualTo(ZonedDateTime.parse("1961-05-08T00:00:00Z[UTC]"))
+    }
+
+
+    /** -------------- Get start/end of week -------------------- */
+    @Test
+    fun `Get start of week`() {
+        val dateTime = ZonedDateTime.parse("1961-05-05T09:50:00Z[UTC]")
+
+        timeProviderSpy.getStartOfWeek(dateTime = dateTime)
+
+        verify (exactly = 1) { timeProviderSpy.getStartOfDayOfWeek(1, dateTime) }
+    }
+
+    @Test
+    fun `Get end of week for specific datetime`() {
+        val endOfWeek = timeProvider.getEndOfWeek(
+            dateTime = ZonedDateTime.parse("1961-07-21T08:12:00Z[UTC]")
+        )
+        assertThat(endOfWeek).isEqualTo(ZonedDateTime.parse("1961-07-24T00:00:00Z[UTC]"))
+    }
+
+
+    /** -------------- Get start/end of month ------------------- */
+    @Test
+    fun `Get start of month`() {
+        val startOfMonth = timeProvider.getStartOfMonth()
+        assertThat(startOfMonth).isEqualTo(ZonedDateTime.parse("1969-07-01T00:00:00Z[UTC]"))
+    }
+
+    @Test
+    fun `Get start of month for specific datetime`() {
+        val startOfMonth = timeProvider.getStartOfMonth(
+            dateTime = ZonedDateTime.parse("1968-12-24T08:59:52Z[UTC]")
+        )
+        assertThat(startOfMonth).isEqualTo(ZonedDateTime.parse("1968-12-01T00:00:00Z[UTC]"))
+    }
+
+    @Test
+    fun `Get end of month`() {
+        val endOfMonth = timeProvider.getEndOfMonth()
+        assertThat(endOfMonth).isEqualTo(ZonedDateTime.parse("1969-08-01T00:00:00Z[UTC]"))
+    }
+
+    @Test
+    fun `Get end of month for specific datetime`() {
+        val endOfMonth = timeProvider.getEndOfMonth(
+            dateTime = ZonedDateTime.parse("1968-12-24T08:59:52Z[UTC]")
+        )
+        assertThat(endOfMonth).isEqualTo(ZonedDateTime.parse("1969-01-01T00:00:00Z[UTC]"))
     }
 }


### PR DESCRIPTION
Fix bug in getDurationString where a duration between one and two days would be formatted to the number of hours left in the day.

Ensure that weekly and monthly goals created by prepopulateDatabase() correctly start at the beginning of the week/month.

Remove offset parameters from TimeProvider methods to simplify testing. Offsets can easily be applied on the returned ZonedDateTime by using the functions plusDays(), plusWeeks(), etc..

Add extensive unit tests for TimeProvider.

Reverse order of "last five goals" in statistics.

Closes #78 and #79.