### PR TITLE
ci: use build artifacts to improve performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,15 @@ jobs:
     - name: Build
       run: ./gradlew assembleDebug
 
-    - name: Upload build folder
+    - name: Tar build files
+      run: tar -cvf build.tar app/build
+
+
+    - name: Upload build tar
       uses: actions/upload-artifact@v4
       with:
           name: build
-          path: app/build
+          path: build.tar
 
   unit-tests:
     name: Unit tests
@@ -71,7 +75,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: build
-        path: app/build
+        path: .
+
+    - name: Extract build files
+      run: tar -xvf build.tar -C app/build
+
+    - name: Show build directory
+      run: ls -la app/build
 
     - name: Unit tests
       run: ./gradlew testDebugUnitTest
@@ -104,7 +114,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build
-          path: app/build
+          path: .
+
+      - name: Extract build files
+        run: tar -xvf build.tar -C app/build
+
+      - name: Show build directory
+        run: ls -la app/build
 
       # API 30+ emulators only have x86_64 system images.
       - name: Get AVD info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
 
   checks:
     name: Checks
+    needs: parse-pull-request
     if: ${{ needs.parse-pull-request.outputs.skip-ci != 'true' }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         path: .
 
     - name: Extract build files
-      run: tar -xvf build.tar -C app/build
+      run: mkdir -p app/build && tar -xvf build.tar -C app/build
 
     - name: Show build directory
       run: ls -la app/build
@@ -117,7 +117,7 @@ jobs:
           path: .
 
       - name: Extract build files
-        run: tar -xvf build.tar -C app/build
+        run: mkdir -p app/build && tar -xvf build.tar -C app/build
 
       - name: Show build directory
         run: ls -la app/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,13 @@ jobs:
       - name: Parse PR body
         id: parse-body
         run: |
-          if (( echo "${{ github.event.pull_request.body }}" | grep -E "build\s?:\s?no" )); then
+          if echo "${{ github.event.pull_request.body }}" | grep -E "build\s?:\s?no" ; then
             echo Skipping CI
             echo "skip-ci=true" >> "$GITHUB_OUTPUT"
           fi
 
   checks:
     name: Checks
-    needs: parse-pull-request
     if: ${{ needs.parse-pull-request.outputs.skip-ci != 'true' }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,31 @@ jobs:
         name: lint-results
         path: app/build/reports/lint-results-debug.html
 
+  build:
+    name: Build
+    needs: checks
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Build
+      run: ./gradlew assembleDebug
+
+    - name: Upload build folder
+      uses: actions/upload-artifact@v4
+      with:
+          name: build
+          path: app/build
+
   unit-tests:
     name: Unit tests
-    needs: checks
+    needs: build
     runs-on: macos-latest
 
     steps: 
@@ -44,10 +66,15 @@ jobs:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: 'temurin'
         cache: gradle
-    - uses: gradle/actions/setup-gradle@v3
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build
+        path: app/build
 
     - name: Unit tests
-      run: ./gradlew test
+      run: ./gradlew testDebugUnitTest
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
@@ -57,7 +84,7 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    needs: checks
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -72,12 +99,12 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
           cache: gradle
-      - uses: gradle/gradle-build-action@v3
-        continue-on-error: true
-        timeout-minutes: 5
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          cache-overwrite-existing: true
-          gradle-home-cache-cleanup: true
+          name: build
+          path: app/build
 
       # API 30+ emulators only have x86_64 system images.
       - name: Get AVD info
@@ -98,7 +125,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           arch: ${{ steps.avd-info.outputs.arch }}
           target: ${{ steps.avd-info.outputs.target }}
-          script: ./gradlew connectedCheck
+          script: ./gradlew connectedDebugAndroidTest
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
     - name: Tar build files
       run: tar -cvf build.tar app/build
 
-
     - name: Upload build tar
       uses: actions/upload-artifact@v4
       with:
@@ -78,7 +77,9 @@ jobs:
         path: .
 
     - name: Extract build files
-      run: tar -xvf build.tar
+      run: |
+        tar -xvf build.tar
+        chmod -R 777 app/build
 
     - name: Show build directory
       run: ls -la app/build
@@ -117,7 +118,9 @@ jobs:
           path: .
 
       - name: Extract build files
-        run: tar -xvf build.tar
+        run: |
+          tar -xvf build.tar
+          chmod -R 777 app/build
         
       - name: Show build directory
         run: ls -la app/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,26 @@ on:
 env:
     JAVA_VERSION: 17
 jobs:
+
+  parse-pull-request:
+    name: Parse pull request
+    runs-on: ubuntu-latest
+    outputs:
+      skip-ci: ${{ steps.parse-body.outputs.skip-ci }}
+
+    steps:
+      - name: Parse PR body
+        id: parse-body
+        run: |
+          if (( echo "${{ github.event.pull_request.body }}" | grep -E "build\s?:\s?no" )); then
+            echo Skipping CI
+            echo "skip-ci=true" >> "$GITHUB_OUTPUT"
+          fi
+
   checks:
     name: Checks
+    needs: parse-pull-request
+    if: ${{ needs.parse-pull-request.outputs.skip-ci != 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +50,10 @@ jobs:
 
   unit-tests:
     name: Unit tests
+    needs: parse-pull-request
+    if: ${{ needs.parse-pull-request.outputs.skip-ci != 'true' }}
     runs-on: macos-latest
+
     steps: 
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
@@ -53,11 +74,15 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
+    needs: parse-pull-request
+    if: ${{ needs.parse-pull-request.outputs.skip-ci != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+
     strategy:
       matrix:
         api-level: [34]
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         path: .
 
     - name: Extract build files
-      run: mkdir -p app/build && tar -xvf build.tar -C app/build
+      run: tar -xvf build.tar
 
     - name: Show build directory
       run: ls -la app/build
@@ -117,8 +117,8 @@ jobs:
           path: .
 
       - name: Extract build files
-        run: mkdir -p app/build && tar -xvf build.tar -C app/build
-
+        run: tar -xvf build.tar
+        
       - name: Show build directory
         run: ls -la app/build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       run: ./gradlew assembleDebug
 
     - name: Tar build files
-      run: tar -cvf build.tar app/build
+      run: tar -cvf build.tar app/build .gradle
 
     - name: Upload build tar
       uses: actions/upload-artifact@v4
@@ -79,7 +79,6 @@ jobs:
     - name: Extract build files
       run: |
         tar -xvf build.tar
-        chmod -R 777 app/build
 
     - name: Show build directory
       run: ls -la app/build
@@ -120,7 +119,7 @@ jobs:
       - name: Extract build files
         run: |
           tar -xvf build.tar
-          chmod -R 777 app/build
+          chmod -R 777 app/build .gradle
         
       - name: Show build directory
         run: ls -la app/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,9 @@ env:
     JAVA_VERSION: 17
 jobs:
 
-  parse-pull-request:
-    name: Parse pull request
-    runs-on: ubuntu-latest
-    outputs:
-      skip-ci: ${{ steps.parse-body.outputs.skip-ci }}
-
-    steps:
-      - name: Parse PR body
-        id: parse-body
-        run: |
-          if echo "${{ github.event.pull_request.body }}" | grep -E "build\s?:\s?no" ; then
-            echo Skipping CI
-            echo "skip-ci=true" >> "$GITHUB_OUTPUT"
-          fi
-
   checks:
     name: Checks
-    needs: parse-pull-request
-    if: ${{ needs.parse-pull-request.outputs.skip-ci != 'true' }}
+    if: ${{ echo "${{ github.event.pull_request.body }}" | grep -E "build\s?:\s?no" }}
     runs-on: ubuntu-latest
 
     steps:
@@ -50,8 +34,7 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    needs: parse-pull-request
-    if: ${{ needs.parse-pull-request.outputs.skip-ci != 'true' }}
+    needs: checks
     runs-on: macos-latest
 
     steps: 
@@ -74,8 +57,7 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    needs: parse-pull-request
-    if: ${{ needs.parse-pull-request.outputs.skip-ci != 'true' }}
+    needs: checks
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
   checks:
     name: Checks
-    if: ${{ echo "${{ github.event.pull_request.body }}" | grep -E "build\s?:\s?no" }}
+    if: "${{ !contains(github.event.pull_request.body, 'build: no') }}"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: build
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps: 
     - uses: actions/checkout@v4
@@ -79,9 +79,6 @@ jobs:
     - name: Extract build files
       run: |
         tar -xvf build.tar
-
-    - name: Show build directory
-      run: ls -la app/build
 
     - name: Unit tests
       run: ./gradlew testDebugUnitTest
@@ -119,10 +116,6 @@ jobs:
       - name: Extract build files
         run: |
           tar -xvf build.tar
-          chmod -R 777 app/build .gradle
-        
-      - name: Show build directory
-        run: ls -la app/build
 
       # API 30+ emulators only have x86_64 system images.
       - name: Get AVD info


### PR DESCRIPTION
This PR adds the 'build' job to the CI-pipeline. Here, the debug build of the app is built and uploaded as an artifact. Both the unit test and the android test jobs can download the build to improve their performance