### PR TITLE
ci: skip ci when explicitly told so with a label "skip-ci"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   checks:
     name: Checks
     # Only run checks if the PR title does not start with 'docs:' and the PR does not have the 'skip-ci' label
-    if: "${{ !startsWith(github.event.pull_request.title, 'docs:') && !contains(github.event.pull_request.label, 'skip-ci') }}"
+    if: "${{ !startsWith(github.event.pull_request.title, 'docs:') && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,19 @@ name: CI
 
 on:
   pull_request:
+    # Only run on PRs with main as target branch
     branches: [ "main" ]
+    # Triggers when a PR is opened, updated or labeled
+    types: [opened, synchronize, reopened, labeled]
+
 env:
     JAVA_VERSION: 17
-jobs:
 
+jobs:
   checks:
     name: Checks
-    if: "${{ !startsWith(github.event.pull_request.title, 'docs:') }}"
+    # Only run checks if the PR title does not start with 'docs:' and the PR does not have the 'skip-ci' label
+    if: "${{ !startsWith(github.event.pull_request.title, 'docs:') && !contains(github.event.pull_request.label, 'skip-ci') }}"
     runs-on: ubuntu-latest
 
     steps:
@@ -143,5 +148,3 @@ jobs:
         with:
           name: instrumentation-test-results-${{ matrix.api-level }}
           path: app/build/reports/androidTests/connected/debug
-
-          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     # Only run on PRs with main as target branch
     branches: [ "main" ]
     # Triggers when a PR is opened, updated or labeled
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, unlabeled]
 
 env:
     JAVA_VERSION: 17


### PR DESCRIPTION
If the label `skip-ci` is set in a PR, it does not anymore trigger the CI build on every push / commit.

It it is removed the CI triggers.