### PR TITLE
Add validation and restoration to database import

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,8 @@ android {
                 keyAlias = System.getenv("SIGNING_KEY_ALIAS")
                 keyPassword = System.getenv("SIGNING_KEY_PASSWORD")
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            logger.warn("No signing configuration found, using debug key (message: ${e.message})")
         }
     }
 

--- a/app/src/main/java/app/musikus/Application.kt
+++ b/app/src/main/java/app/musikus/Application.kt
@@ -13,7 +13,6 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
-import androidx.activity.result.ActivityResultLauncher
 import dagger.hilt.android.HiltAndroidApp
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -83,13 +82,8 @@ class Musikus : Application() {
             IO_EXECUTOR.execute(f)
         }
 
-        var exportLauncher: ActivityResultLauncher<String>? = null
-        var importLauncher: ActivityResultLauncher<Array<String>>? = null
-
         var noSessionsYet = true
         var serviceIsRunning = false
-
-        const val USER_PREFERENCES_NAME = "user_preferences"
 
         fun getRandomQuote(context: Context) : CharSequence {
             return context.resources.getTextArray(R.array.quotes).random()
@@ -97,16 +91,6 @@ class Musikus : Application() {
 
         fun dp(context: Context, dp: Int): Float {
             return context.resources.displayMetrics.density * dp
-        }
-
-
-        fun importDatabase() {
-            importLauncher?.launch(arrayOf("*/*"))
-        }
-
-
-        fun exportDatabase() {
-            exportLauncher?.launch("musikus_backup")
         }
     }
 }

--- a/app/src/main/java/app/musikus/database/MusikusDatabase.kt
+++ b/app/src/main/java/app/musikus/database/MusikusDatabase.kt
@@ -126,9 +126,6 @@ abstract class MusikusDatabase : RoomDatabase() {
     }
 
     fun import(inputStream: InputStream) {
-        // close the database to collect all logs
-        close()
-
         // delete old database
         databaseFile.delete()
 

--- a/app/src/main/java/app/musikus/database/MusikusDatabase.kt
+++ b/app/src/main/java/app/musikus/database/MusikusDatabase.kt
@@ -3,17 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2022-2024 Matthias Emde
- *
- * Parts of this software are licensed under the MIT license
- *
- * Copyright (c) 2022, Javier Carbone, author Matthias Emde
- * Additions and modifications, author Michael Prommersberger
+ * Copyright (c) 2022-2024 Matthias Emde, Michael Prommersberger
  */
 
 package app.musikus.database
 
-import android.app.Application
 import android.content.ContentValues
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
@@ -47,6 +41,9 @@ import app.musikus.utils.IdProvider
 import app.musikus.utils.TimeProvider
 import app.musikus.utils.prepopulateDatabase
 import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
 import java.nio.ByteBuffer
 import java.time.Instant
 import java.time.ZoneId
@@ -92,6 +89,36 @@ abstract class MusikusDatabase : RoomDatabase() {
 
     lateinit var timeProvider: TimeProvider
     lateinit var idProvider: IdProvider
+    lateinit var databaseFile: File
+
+
+    /**
+     *  ---------------- Datbase Export/Import ----------------
+     */
+
+    fun export(outputStream: OutputStream) {
+        // close the database to collect all logs
+        close()
+        // copy database file to output stream
+        databaseFile.inputStream().let { inputStream ->
+            inputStream.copyTo(outputStream)
+            inputStream.close()
+        }
+        outputStream.close()
+    }
+
+    fun import(inputStream: InputStream) {
+        // close the database to collect all logs
+        close()
+        // delete old database
+        databaseFile.delete()
+        // copy new database from input stream
+        databaseFile.outputStream().let { outputStream ->
+            inputStream.copyTo(outputStream)
+            inputStream.close()
+            outputStream.close()
+        }
+    }
 
     companion object {
         const val DATABASE_NAME = "musikus-database"

--- a/app/src/main/java/app/musikus/database/MusikusDatabase.kt
+++ b/app/src/main/java/app/musikus/database/MusikusDatabase.kt
@@ -151,13 +151,11 @@ abstract class MusikusDatabase : RoomDatabase() {
                 // prepopulate the database after onCreate was called
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)
-                    // prepopulate the database if in debug configuration and not in import mode
-                    if (BuildConfig.DEBUG) {
-                        if (databaseProvider != null) {
-                            ioThread { runBlocking {
-                                prepopulateDatabase(databaseProvider.get())
-                            } }
-                        }
+                    // prepopulate the database if in debug configuration
+                    if (BuildConfig.DEBUG && databaseProvider != null) {
+                        ioThread { runBlocking {
+                            prepopulateDatabase(databaseProvider.get())
+                        } }
                     }
                 }
             }).build()

--- a/app/src/main/java/app/musikus/datastore/UserPreferences.kt
+++ b/app/src/main/java/app/musikus/datastore/UserPreferences.kt
@@ -14,6 +14,8 @@ import app.musikus.utils.LibraryFolderSortMode
 import app.musikus.utils.LibraryItemSortMode
 import app.musikus.utils.SortDirection
 
+const val USER_PREFERENCES_NAME = "user_preferences"
+
 interface EnumWithLabel {
     val label: String
 }

--- a/app/src/main/java/app/musikus/di/MainModule.kt
+++ b/app/src/main/java/app/musikus/di/MainModule.kt
@@ -28,7 +28,6 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import javax.inject.Provider
 import javax.inject.Singleton
 
@@ -84,7 +83,6 @@ object MainModule {
             this.timeProvider = timeProvider
             this.idProvider = idProvider
             this.databaseFile = app.getDatabasePath(MusikusDatabase.DATABASE_NAME)
-            this.databaseBackupFile = app.getDatabasePath(MusikusDatabase.DATABASE_BACKUP_NAME)
         }
     }
 }

--- a/app/src/main/java/app/musikus/di/MainModule.kt
+++ b/app/src/main/java/app/musikus/di/MainModule.kt
@@ -28,6 +28,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import javax.inject.Provider
 import javax.inject.Singleton
 
@@ -83,6 +84,7 @@ object MainModule {
             this.timeProvider = timeProvider
             this.idProvider = idProvider
             this.databaseFile = app.getDatabasePath(MusikusDatabase.DATABASE_NAME)
+            this.databaseBackupFile = app.getDatabasePath(MusikusDatabase.DATABASE_BACKUP_NAME)
         }
     }
 }

--- a/app/src/main/java/app/musikus/di/MainModule.kt
+++ b/app/src/main/java/app/musikus/di/MainModule.kt
@@ -15,8 +15,8 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStoreFile
-import app.musikus.Musikus
 import app.musikus.database.MusikusDatabase
+import app.musikus.datastore.USER_PREFERENCES_NAME
 import app.musikus.utils.IdProvider
 import app.musikus.utils.IdProviderImpl
 import app.musikus.utils.TimeProvider
@@ -58,7 +58,7 @@ object MainModule {
                 emptyPreferences()
             },
             scope = CoroutineScope(IO + SupervisorJob()),
-            produceFile = { app.preferencesDataStoreFile(Musikus.USER_PREFERENCES_NAME) }
+            produceFile = { app.preferencesDataStoreFile(USER_PREFERENCES_NAME) }
         )
     }
 
@@ -82,6 +82,7 @@ object MainModule {
         ).apply {
             this.timeProvider = timeProvider
             this.idProvider = idProvider
+            this.databaseFile = app.getDatabasePath(MusikusDatabase.DATABASE_NAME)
         }
     }
 }

--- a/app/src/main/java/app/musikus/ui/MainActivity.kt
+++ b/app/src/main/java/app/musikus/ui/MainActivity.kt
@@ -150,13 +150,11 @@ class MainActivity : PermissionCheckerActivity() {
                     if (isNewDatabaseValid) {
                         message = "Backup successfully loaded"
                     } else {
-                        // If the import was invalid, throw an error to restore the backup
-                        message = "Invalid database. Restoring backup..."
                         throw Exception("Invalid database")
                     }
                 } catch (e: Exception) {
                     // If an error occurred, restore the backup
-                    Log.d("MainActivity", "Error loading backup: ${e.message}")
+                    Log.e("MainActivity", "Error loading backup: ${e.message}")
                     backupFile.copyTo(database.databaseFile, overwrite = true)
                 } finally {
                     // Finally, delete the backup file

--- a/app/src/main/java/app/musikus/ui/settings/backup/BackupScreen.kt
+++ b/app/src/main/java/app/musikus/ui/settings/backup/BackupScreen.kt
@@ -30,8 +30,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import app.musikus.Musikus
+import app.musikus.ui.MainActivity
 import app.musikus.ui.theme.spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -67,11 +68,13 @@ fun BackupScreen(
 
             Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
 
+            val activity: MainActivity = LocalContext.current as MainActivity
+
             Button(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = MaterialTheme.spacing.extraLarge),
-                onClick = { Musikus.exportDatabase() },
+                onClick = { activity.exportDatabase() },
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -91,7 +94,7 @@ fun BackupScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = MaterialTheme.spacing.extraLarge),
-                onClick = { Musikus.importDatabase() },
+                onClick = { activity.importDatabase() },
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
This PR adds a backup file to the import process which is used to restore the state from before the import in case anything goes wrong. 

Also generally improves the whole export/import code.

Fixes #13