### PR TITLE
ci: add github workflow to validate pr title

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -22,7 +22,7 @@ jobs:
           PR_TITLE="${{ github.event.pull_request.title }}"
           echo "PR Title: $PR_TITLE"
           if [[ ! "$PR_TITLE" =~ ^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(\([a-zA-Z0-9_\-]+\))?:\ [a-z].* ]]; then
-            echo "PR title does not conform to the conventional commit pattern" > title_error.txt
+            echo "PR title does not conform to the [conventional commit](https://www.conventionalcommits.org/) pattern." > title_error.txt
             gh pr comment ${{ github.event.pull_request.number }} --body-file title_error.txt
             exit 1
           fi

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Validate PR title
         id: validate_title
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"
           echo "PR Title: $PR_TITLE"

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,4 +1,4 @@
-name: Validate PR Title
+name: VALIDATE-PR-TITLE
 
 on:
   pull_request:
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Validate PR title
         id: validate_title
         env:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -2,20 +2,22 @@ name: VALIDATE-PR-TITLE
 
 on:
   pull_request:
+    # Only run on PRs with main as target branch
+    branches: [ "main" ]
     types: [ opened, edited, reopened ]
 
 jobs:
   validate-pr-title:
+    name: Validate PR title
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Validate PR title
         id: validate_title
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_PAT }}
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"
           echo "PR Title: $PR_TITLE"

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,25 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [ opened, edited, reopened ]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate PR title
+        id: validate_title
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          echo "PR Title: $PR_TITLE"
+          if [[ ! "$PR_TITLE" =~ ^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(\([a-zA-Z0-9_\-]+\))?:\ [a-z].* ]]; then
+            echo "PR title does not conform to the conventional commit pattern" > title_error.txt
+            gh pr comment ${{ github.event.pull_request.number }} --body-file title_error.txt
+            exit 1
+          fi
+
+      - name: PR title is valid
+        if: success()
+        run: echo "PR title conforms to the conventional commit pattern"


### PR DESCRIPTION
This PR adds a workflow to validate the titles of our PRs to confirm with the [_conventional commits_](https://www.conventionalcommits.org/en/v1.0.0/) pattern.

Originally, I wanted to implement some sort of commit hook or branch rule to ensure only commits in this format can be pushed to master, but this was not possible when using squash merges. Ultimately I figured that the github UI automatically fills out the commit message to be the title of the PR (+ the PR number) which is why I settled on validating the PR titles. This will also help us to keep the PRs organized and easy to sort/filter.