### PR TITLE
fix: goal card erroneously showing negative remaining time

### DIFF
--- a/app/src/main/java/app/musikus/core/presentation/utils/DurationFormatter.kt
+++ b/app/src/main/java/app/musikus/core/presentation/utils/DurationFormatter.kt
@@ -166,23 +166,27 @@ fun getDurationString(
             }
             DurationFormat.PRETTY_APPROX -> {
                 append(when {
-                    // if time left is larger than a day, show the number of begun days
+                    // if time left is at least one day, show the number of begun days
                     days > 0 -> "${days + 1} days"
-                    // if days are zero, but hours is larger than 1, show the number of begun hours
+                    // if days are zero, but hours is at least one, show the number of begun hours
                     hours > 0 -> "${hours + 1} hours"
-                    // else, show the number of begun minutes
-                    else -> "${minutes + 1} minutes"
+                    // if the duration is less than one hour but still positive, show the number of begun minutes
+                    duration.isPositive() -> "${minutes + 1} minutes"
+                    // if duration is zero or negative, throw an error
+                    else -> throw (IllegalArgumentException("Duration must be positive"))
                 })
             }
 
             DurationFormat.PRETTY_APPROX_SHORT -> {
                 append(when {
-                    // if time left is larger than a day, show the number of begun days
+                    // if time left is at least one day, show the number of begun days
                     days > 0 -> "${days + 1} days"
-                    // if days are zero, but hours is larger than 1, show the number of begun hours
+                    // if days are zero, but hours is at least one, show the number of begun hours
                     hours > 0 -> "${hours + 1}h"
-                    // else, show the number of begun minutes
-                    else -> "${minutes + 1}m"
+                    // if the duration is less than one hour but still positive, show the number of begun minutes
+                    duration.isPositive() -> "${minutes + 1}m"
+                    // if the duration is zero or negative, throw an error
+                    else -> throw (IllegalArgumentException("Duration must be positive"))
                 })
             }
         }

--- a/app/src/main/java/app/musikus/goals/presentation/GoalCard.kt
+++ b/app/src/main/java/app/musikus/goals/presentation/GoalCard.kt
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2022 Matthias Emde
+ * Copyright (c) 2022-2024 Matthias Emde
  */
 
 package app.musikus.goals.presentation
@@ -45,13 +45,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.musikus.R
-import app.musikus.goals.data.entities.GoalType
-import app.musikus.core.presentation.utils.DurationFormat
-import app.musikus.core.presentation.utils.getDurationString
-import app.musikus.core.presentation.theme.libraryItemColors
-import app.musikus.goals.domain.GoalInstanceWithProgressAndDescriptionWithLibraryItems
 import app.musikus.core.domain.TimeProvider
+import app.musikus.core.presentation.theme.libraryItemColors
+import app.musikus.core.presentation.utils.DurationFormat
 import app.musikus.core.presentation.utils.asAnnotatedString
+import app.musikus.core.presentation.utils.getDurationString
+import app.musikus.goals.data.entities.GoalType
+import app.musikus.goals.domain.GoalInstanceWithProgressAndDescriptionWithLibraryItems
 import java.time.temporal.ChronoUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -134,10 +134,10 @@ fun GoalCard(
                         Text(
                             modifier = Modifier.padding(8.dp),
                             maxLines = 1,
-                            text= stringResource(
+                            text = if (remainingTime.isPositive()) stringResource(
                                 R.string.time_left,
                                 getDurationString(remainingTime, DurationFormat.PRETTY_APPROX)
-                            )
+                            ) else stringResource(R.string.time_over),
                         )
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
     <string name="deleteLibraryItemsFailSnackbar">Some items could not be deleted, because they are associated with at least one goal</string>
     <string name="deleteDialogConfirm">Delete</string>
     <string name="time_left">%1$s left</string>
+    <string name="time_over">Expired</string>
     <plurals name="time_period_day">
         <item quantity="one">in one day</item>
         <item quantity="other">in %d days</item>


### PR DESCRIPTION
This PR adds a new case to the `PRETTY` duration formatting which throws an error if the duration is negative. The goal card then checks whether the remaining duration is negative and displays 'Expired' if it is.