### PR TITLE
fix: statistics not being shown when there are no recent sessions

### DIFF
--- a/app/src/androidTest/java/app/musikus/sessionslist/di/TestSessionsUseCasesModule.kt
+++ b/app/src/androidTest/java/app/musikus/sessionslist/di/TestSessionsUseCasesModule.kt
@@ -14,6 +14,7 @@ import app.musikus.sessions.domain.SessionRepository
 import app.musikus.sessions.domain.usecase.AddSessionUseCase
 import app.musikus.sessions.domain.usecase.DeleteSessionsUseCase
 import app.musikus.sessions.domain.usecase.EditSessionUseCase
+import app.musikus.sessions.domain.usecase.GetAllSessionsUseCase
 import app.musikus.sessions.domain.usecase.GetSessionByIdUseCase
 import app.musikus.sessions.domain.usecase.GetSessionsForDaysForMonthsUseCase
 import app.musikus.sessions.domain.usecase.GetSessionsInTimeframeUseCase
@@ -37,6 +38,7 @@ object TestSessionsUseCasesModule {
         libraryUseCases: LibraryUseCases,
     ): SessionsUseCases {
         return SessionsUseCases(
+            getAll = GetAllSessionsUseCase(sessionRepository),
             getSessionsForDaysForMonths = GetSessionsForDaysForMonthsUseCase(sessionRepository),
             getInTimeframe = GetSessionsInTimeframeUseCase(sessionRepository),
             getById = GetSessionByIdUseCase(sessionRepository),
@@ -46,5 +48,4 @@ object TestSessionsUseCasesModule {
             restore = RestoreSessionsUseCase(sessionRepository),
         )
     }
-
 }

--- a/app/src/main/java/app/musikus/core/presentation/utils/DurationFormatter.kt
+++ b/app/src/main/java/app/musikus/core/presentation/utils/DurationFormatter.kt
@@ -176,27 +176,29 @@ fun getDurationString(
             DurationFormat.PRETTY_APPROX -> {
                 append(
                     when {
-                        // if time left is larger than a day, show the number of begun days
+                        // if time left is at least one day, show the number of begun days
                         days > 0 -> "${days + 1} days"
-                        // if days are zero, but hours is larger than 1, show the number of begun hours
+                        // if days are zero, but hours is at least one, show the number of begun hours
                         hours > 0 -> "${hours + 1} hours"
-                        // else, show the number of begun minutes
-                        else -> "${minutes + 1} minutes"
-                    }
-                )
+                        // if the duration is less than one hour but still positive, show the number of begun minutes
+                        duration.isPositive() -> "${minutes + 1} minutes"
+                    // if duration is zero or negative, throw an error
+                    else -> throw (IllegalArgumentException("Duration must be positive"))
+                })
             }
 
             DurationFormat.PRETTY_APPROX_SHORT -> {
                 append(
                     when {
-                        // if time left is larger than a day, show the number of begun days
+                        // if time left is at least one day, show the number of begun days
                         days > 0 -> "${days + 1} days"
-                        // if days are zero, but hours is larger than 1, show the number of begun hours
+                        // if days are zero, but hours is at least one, show the number of begun hours
                         hours > 0 -> "${hours + 1}h"
-                        // else, show the number of begun minutes
-                        else -> "${minutes + 1}m"
-                    }
-                )
+                        // if the duration is less than one hour but still positive, show the number of begun minutes
+                        duration.isPositive() -> "${minutes + 1}m"
+                    // if the duration is zero or negative, throw an error
+                    else -> throw (IllegalArgumentException("Duration must be positive"))
+                })
             }
         }
     }

--- a/app/src/main/java/app/musikus/goals/presentation/GoalCard.kt
+++ b/app/src/main/java/app/musikus/goals/presentation/GoalCard.kt
@@ -143,10 +143,10 @@ fun GoalCard(
                         Text(
                             modifier = Modifier.padding(8.dp),
                             maxLines = 1,
-                            text = stringResource(
+                            text = if (remainingTime.isPositive()) stringResource(
                                 R.string.core_time_left,
                                 getDurationString(remainingTime, DurationFormat.PRETTY_APPROX)
-                            )
+                            ) else stringResource(R.string.goals_goal_card_expired),
                         )
                     }
                 }

--- a/app/src/main/java/app/musikus/sessions/data/SessionRepository.kt
+++ b/app/src/main/java/app/musikus/sessions/data/SessionRepository.kt
@@ -38,6 +38,8 @@ class SessionRepositoryImpl(
     override val sessions = sessionDao.getAllAsFlow()
     override val sections = sectionDao.getAllAsFlow()
 
+    override val sessionsWithSectionsWithLibraryItems =
+        sessionDao.getAllWithSectionsWithLibraryItems()
     override val orderedSessionsWithSectionsWithLibraryItems = sessionDao.getOrderedWithSectionsWithLibraryItems()
     override suspend fun getSession(
         id: UUID

--- a/app/src/main/java/app/musikus/sessions/data/daos/SessionDao.kt
+++ b/app/src/main/java/app/musikus/sessions/data/daos/SessionDao.kt
@@ -141,6 +141,12 @@ abstract class SessionDao(
 
     @Transaction
     @RewriteQueriesToDropUnusedColumns
+    @Query("SELECT * FROM session WHERE deleted=0")
+    abstract fun getAllWithSectionsWithLibraryItems()
+            : Flow<List<SessionWithSectionsWithLibraryItems>>
+
+    @Transaction
+    @RewriteQueriesToDropUnusedColumns
     @Query(
         """
     SELECT session.*

--- a/app/src/main/java/app/musikus/sessions/di/SessionsUseCasesModule.kt
+++ b/app/src/main/java/app/musikus/sessions/di/SessionsUseCasesModule.kt
@@ -13,6 +13,7 @@ import app.musikus.sessions.domain.SessionRepository
 import app.musikus.sessions.domain.usecase.AddSessionUseCase
 import app.musikus.sessions.domain.usecase.DeleteSessionsUseCase
 import app.musikus.sessions.domain.usecase.EditSessionUseCase
+import app.musikus.sessions.domain.usecase.GetAllSessionsUseCase
 import app.musikus.sessions.domain.usecase.GetSessionByIdUseCase
 import app.musikus.sessions.domain.usecase.GetSessionsForDaysForMonthsUseCase
 import app.musikus.sessions.domain.usecase.GetSessionsInTimeframeUseCase
@@ -35,6 +36,7 @@ object SessionsUseCasesModule {
         libraryUseCases: LibraryUseCases
     ): SessionsUseCases {
         return SessionsUseCases(
+            getAll = GetAllSessionsUseCase(sessionRepository),
             getSessionsForDaysForMonths = GetSessionsForDaysForMonthsUseCase(sessionRepository),
             getInTimeframe = GetSessionsInTimeframeUseCase(sessionRepository),
             getById = GetSessionByIdUseCase(sessionRepository),

--- a/app/src/main/java/app/musikus/sessions/domain/Types.kt
+++ b/app/src/main/java/app/musikus/sessions/domain/Types.kt
@@ -31,7 +31,9 @@ interface SessionRepository {
     val sessions: Flow<List<Session>>
     val sections: Flow<List<Section>>
 
+    val sessionsWithSectionsWithLibraryItems: Flow<List<SessionWithSectionsWithLibraryItems>>
     val orderedSessionsWithSectionsWithLibraryItems: Flow<List<SessionWithSectionsWithLibraryItems>>
+
     suspend fun getSession(id: UUID): SessionWithSectionsWithLibraryItems
 
     fun sessionsInTimeframe(timeframe: Timeframe): Flow<List<SessionWithSectionsWithLibraryItems>>

--- a/app/src/main/java/app/musikus/sessions/domain/usecase/GetAllSessionsUseCase.kt
+++ b/app/src/main/java/app/musikus/sessions/domain/usecase/GetAllSessionsUseCase.kt
@@ -1,0 +1,22 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2024 Matthias Emde
+ */
+
+package app.musikus.sessions.domain.usecase
+
+import app.musikus.core.data.SessionWithSectionsWithLibraryItems
+import app.musikus.sessions.domain.SessionRepository
+import kotlinx.coroutines.flow.Flow
+
+class GetAllSessionsUseCase(
+    private val sessionsRepository: SessionRepository
+) {
+
+    operator fun invoke(): Flow<List<SessionWithSectionsWithLibraryItems>> {
+        return sessionsRepository.sessionsWithSectionsWithLibraryItems
+    }
+}

--- a/app/src/main/java/app/musikus/sessions/domain/usecase/SessionsUseCases.kt
+++ b/app/src/main/java/app/musikus/sessions/domain/usecase/SessionsUseCases.kt
@@ -9,6 +9,7 @@
 package app.musikus.sessions.domain.usecase
 
 data class SessionsUseCases(
+    val getAll: GetAllSessionsUseCase,
     val getSessionsForDaysForMonths: GetSessionsForDaysForMonthsUseCase,
     val getInTimeframe: GetSessionsInTimeframeUseCase,
     val getById: GetSessionByIdUseCase,

--- a/app/src/main/java/app/musikus/statistics/presentation/StatisticsScreen.kt
+++ b/app/src/main/java/app/musikus/statistics/presentation/StatisticsScreen.kt
@@ -264,7 +264,7 @@ fun StatisticsCurrentMonth(
 
 @Composable
 fun StatisticsSessionsCard(
-    uiState: StatisticsPracticeDurationCardUiState,
+    uiState: StatisticsSessionsCardUiState,
     navigateToSessionStatistics: () -> Unit,
 ) {
     ElevatedCard(
@@ -396,7 +396,7 @@ fun StatisticsSessionsCard(
 
 @Composable
 fun StatisticsGoalsCard(
-    uiState: StatisticsGoalCardUiState,
+    uiState: StatisticsGoalsCardUiState,
     navigateToGoalStatistics: () -> Unit,
 ) {
     ElevatedCard(

--- a/app/src/main/res/values/goals_strings.xml
+++ b/app/src/main/res/values/goals_strings.xml
@@ -59,6 +59,7 @@
 
     <!-- GoalCard -->
     <string name="goals_goal_card_achieved">Goal achieved!</string>
+    <string name="goals_goal_card_expired">Goal expired</string>
 
     <!-- GoalDialog -->
     <string name="goals_goal_dialog_title">Create a new goal</string>

--- a/app/src/test/java/app/musikus/sessions/data/FakeSessionRepository.kt
+++ b/app/src/test/java/app/musikus/sessions/data/FakeSessionRepository.kt
@@ -42,6 +42,9 @@ class FakeSessionRepository(
         get() = throw NotImplementedError()
     override val sections: Flow<List<Section>>
         get() = flowOf(_sessions.flatMap { session -> session.sections.map { it.section } })
+
+    override val sessionsWithSectionsWithLibraryItems: Flow<List<SessionWithSectionsWithLibraryItems>>
+        get() = flowOf(_sessions)
     override val orderedSessionsWithSectionsWithLibraryItems: Flow<List<SessionWithSectionsWithLibraryItems>>
         get() = flowOf(_sessions.sortedByDescending { it.startTimestamp })
 


### PR DESCRIPTION
This PR fixes a bug which would result in the session statistics card not being shown if there are no recent session.

It does so by simply getting _all_ sessions which we need to do anyways for showing the rating statistics.