### PR TITLE
ci: add final stage to CI pipeline for GitHub status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           path: app/build/reports/androidTests/connected/debug
 
   final-check:
-    name: Final Check
+    name: CI checks passed
     needs: [ checks, build, unit-tests, instrumentation-tests ]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,12 @@ jobs:
         with:
           name: instrumentation-test-results-${{ matrix.api-level }}
           path: app/build/reports/androidTests/connected/debug
+
+  final-check:
+    name: Final Check
+    needs: [ checks, build, unit-tests, instrumentation-tests ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: All stages passed
+        run: echo "All stages passed successfully! 🎉"


### PR DESCRIPTION
This PR adds a final-check stage to the CI pipeline which can be queried by GitHub status checks instead of having to check each stage individually.