### PR TITLE
ci: fix license check and add androidTest to detekt source set

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,6 +130,13 @@ detekt {
     // version found will be used. Override to stay on the same version.
     toolVersion = DetektSettings.VERSION
 
+    // Set the source directories for detekt to analyze (androidTest not included by default).
+    source.setFrom(
+        "src/main/java",
+        "src/test/java",
+        "src/androidTest/java",
+    )
+
     // Point to your custom config defining rules to run, overwriting default behavior
     config.setFrom("$projectDir/${DetektSettings.CONFIG_FILE}")
 

--- a/tools/check_license_headers.py
+++ b/tools/check_license_headers.py
@@ -56,7 +56,7 @@ kt_license_pattern = re.compile(r'/\*\n'
 
 # Function to fetch the files that were just commited to git
 def get_committed_files():
-    result = subprocess.run(['git', 'diff', '--name-only', 'origin/main', 'HEAD'], capture_output=True, text=True)
+    result = subprocess.run(['git', 'diff', '--name-only', '--diff-filter=ACMRT', 'origin/main', 'HEAD'], capture_output=True, text=True)
     files = result.stdout.splitlines()
 
     return [f'{project_path}/{f}' for f in files]

--- a/tools/hooks/post-commit.hook
+++ b/tools/hooks/post-commit.hook
@@ -8,7 +8,7 @@ if ! ./gradlew checkLicense; then
 fi
 
 # Get the list of files changed in the most recent commit
-CHANGED_FILES=$(git diff --name-only origin/main HEAD | tr '\n' ':')
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/main HEAD | tr '\n' ':')
 export CHANGED_FILES
 
 # Run detekt on changed files


### PR DESCRIPTION
Previously, the license check looked at all files in `git diff --name-only origin/main HEAD` which included deleted files. `--diff-filter=ACMRT` filters out deleted files so the license check works correctly.

Also, the detekt config did not include `src/androidTest/java` by default, so I had to add it manually.