### PR TITLE
ci: improve triggers and discord webhook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    # Only run on PRs with main as target branch
-    branches: [ "main" ]
     # Triggers when a PR is opened, updated or labeled
     types: [opened, synchronize, reopened, unlabeled]
 

--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -15,15 +15,18 @@ jobs:
       - name: Send Discord notification for PR
         if: github.event_name == 'pull_request'
         run: |
-          response_code=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
+          BODY=$'${{ github.event.pull_request.body }}'
+          response=$(curl -s -w "\n%{http_code}" -H "Content-Type: application/json" \
             -X POST \
             -d "$(jq -n --arg title "${{ github.event.pull_request.title }}" \
             --arg url "${{ github.event.pull_request.html_url }}" \
-            --arg body "${{ github.event.pull_request.body }}" \
+            --arg body "$(echo $BODY | sed 's/`/\\`/g')" \
             --arg branch "${{ github.event.pull_request.head.ref }}" \
             '{"content": "📣 **New Pull Request**: [\($title)](\($url))\n\n📝 **Description**: \($body)\n\n🚀 **Branch**: \($branch)"}')" \
             ${{ secrets.DISCORD_WEBHOOK_URL }})
-          if [ "$response_code" -ne 200 ]; then
+          echo "$response"
+          response_code=$(echo "$response" | tail -n1)
+          if [ "$response_code" -ne 204 ]; then
             echo "Failed to send Discord notification"
             exit 1
           fi
@@ -31,15 +34,18 @@ jobs:
       - name: Send Discord notification for Release
         if: github.event_name == 'release'
         run: |
-          response_code=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
+          BODY=$'${{ github.event.release.body }}'
+          response=$(curl -s -w "%{http_code}" -H "Content-Type: application/json" \
           -X POST \
-          -d "$(jq -n --arg title "${{ github.event.pull_request.title }}" \
-            --arg url "${{ github.event.pull_request.html_url }}" \
-            --arg body "${{ github.event.pull_request.body }}" \
+          -d "$(jq -n --arg title "${{ github.event.release.title }}" \
+            --arg url "${{ github.event.release.html_url }}" \
+            --arg body "$(echo $BODY | sed 's/`/\\`/g')" \
             --arg tag "${{ github.event.release.tag_name }}" \
             '{"content": "🎉 **New Release**: [\($title)](\($url))\n\n📦 **Version**: \($tag)\n\n📝 **Description**: \($body)"}')" \
           ${{ secrets.DISCORD_WEBHOOK_URL }})
-          if [ "$response_code" -ne 200 ]; then
+          echo "$response"
+          response_code=$(echo "$response" | tail -n1)
+          if [ "$response_code" -ne 204 ]; then
             echo "Failed to send Discord notification"
             exit 1
           fi

--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -2,7 +2,7 @@ name: DISCORD-WEBHOOK
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
   release:
     types: [published]
 
@@ -15,15 +15,23 @@ jobs:
       - name: Send Discord notification for PR
         if: github.event_name == 'pull_request'
         run: |
-          curl -H "Content-Type: application/json" \
+          response=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
           -X POST \
           -d "{\"content\": \"📣 **New Pull Request**: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})\n\n📝 **Description**: ${{ github.event.pull_request.body }}\n\n🚀 **Branch**: ${{ github.event.pull_request.head.ref }}\"}" \
-          ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ${{ secrets.DISCORD_WEBHOOK_URL }})
+          if [ "$response" -ne 200 ]; then
+            echo "Failed to send Discord notification"
+            exit 1
+          fi
 
       - name: Send Discord notification for Release
         if: github.event_name == 'release'
         run: |
-          curl -H "Content-Type: application/json" \
+          response=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
           -X POST \
           -d "{\"content\": \"🎉 **New Release**: [${{ github.event.release.name }}](${{ github.event.release.html_url }})\n\n📦 **Version**: ${{ github.event.release.tag_name }}\n\n📝 **Description**: ${{ github.event.release.body }}\"}" \
-          ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ${{ secrets.DISCORD_WEBHOOK_URL }})
+          if [ "$response" -ne 200 ]; then
+            echo "Failed to send Discord notification"
+            exit 1
+          fi

--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -15,11 +15,15 @@ jobs:
       - name: Send Discord notification for PR
         if: github.event_name == 'pull_request'
         run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
-          -X POST \
-          -d "{\"content\": \"📣 **New Pull Request**: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})\n\n📝 **Description**: ${{ github.event.pull_request.body }}\n\n🚀 **Branch**: ${{ github.event.pull_request.head.ref }}\"}" \
-          ${{ secrets.DISCORD_WEBHOOK_URL }})
-          if [ "$response" -ne 200 ]; then
+          response_code=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
+            -X POST \
+            -d "$(jq -n --arg title "${{ github.event.pull_request.title }}" \
+            --arg url "${{ github.event.pull_request.html_url }}" \
+            --arg body "${{ github.event.pull_request.body }}" \
+            --arg branch "${{ github.event.pull_request.head.ref }}" \
+            '{"content": "📣 **New Pull Request**: [\($title)](\($url))\n\n📝 **Description**: \($body)\n\n🚀 **Branch**: \($branch)"}')" \
+            ${{ secrets.DISCORD_WEBHOOK_URL }})
+          if [ "$response_code" -ne 200 ]; then
             echo "Failed to send Discord notification"
             exit 1
           fi
@@ -27,11 +31,15 @@ jobs:
       - name: Send Discord notification for Release
         if: github.event_name == 'release'
         run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
+          response_code=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
           -X POST \
-          -d "{\"content\": \"🎉 **New Release**: [${{ github.event.release.name }}](${{ github.event.release.html_url }})\n\n📦 **Version**: ${{ github.event.release.tag_name }}\n\n📝 **Description**: ${{ github.event.release.body }}\"}" \
+          -d "$(jq -n --arg title "${{ github.event.pull_request.title }}" \
+            --arg url "${{ github.event.pull_request.html_url }}" \
+            --arg body "${{ github.event.pull_request.body }}" \
+            --arg tag "${{ github.event.release.tag_name }}" \
+            '{"content": "🎉 **New Release**: [\($title)](\($url))\n\n📦 **Version**: \($tag)\n\n📝 **Description**: \($body)"}')" \
           ${{ secrets.DISCORD_WEBHOOK_URL }})
-          if [ "$response" -ne 200 ]; then
+          if [ "$response_code" -ne 200 ]; then
             echo "Failed to send Discord notification"
             exit 1
           fi

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -2,8 +2,7 @@ name: RELEASE-ALPHA
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 17 * * 0'
+
 env:
   JAVA_VERSION: 17
   UPLOAD_KEY_STORE_PATH: ${{ github.workspace }}/upload_keystore.jks

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -3,7 +3,7 @@ name: RELEASE-NIGHTLY
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * 0,2-6'
+    - cron: '0 3 * * *'
 env:
   JAVA_VERSION: 17
   RELEASE_BOT_SIGNING_KEY_PATH: ${{ github.workspace }}/signing_key

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -2,7 +2,7 @@ name: VALIDATE-PR-TITLE
 
 on:
   pull_request:
-    types: [ opened, edited, reopened ]
+    types: [ opened, synchronize, edited, reopened ]
 
 jobs:
   validate-pr-title:
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Ensure sync with GitHub
-        run: echo "Giving GitHub a bit of time before continuing..." && sleep 3
-
       - uses: actions/checkout@v4
 
       - name: Validate PR title

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -2,8 +2,6 @@ name: VALIDATE-PR-TITLE
 
 on:
   pull_request:
-    # Only run on PRs with main as target branch
-    branches: [ "main" ]
     types: [ opened, edited, reopened ]
 
 jobs:
@@ -12,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Ensure sync with GitHub
+        run: echo "Giving GitHub a bit of time before continuing..." && sleep 3
+
       - uses: actions/checkout@v4
 
       - name: Validate PR title


### PR DESCRIPTION
This PR performs some minor improvements on the CI
- Run CI on all branches, not just `main`
- Correctly fail the discord webhook if curl returns anything but `200 OK`
- Validate PR title on every push since GitHub discards older action results

Fixes: #129 