### PR TITLE
feat: add announcement dialog

### DIFF
--- a/app/src/androidTest/java/app/musikus/repository/FakeUserPreferencesRepository.kt
+++ b/app/src/androidTest/java/app/musikus/repository/FakeUserPreferencesRepository.kt
@@ -40,7 +40,8 @@ class FakeUserPreferencesRepository : UserPreferencesRepository {
             goalsSortMode = GoalsSortMode.DEFAULT,
             goalsSortDirection = SortDirection.DEFAULT,
             showPausedGoals = true,
-            metronomeSettings = MetronomeSettings.DEFAULT
+            metronomeSettings = MetronomeSettings.DEFAULT,
+            idOfLastAnnouncementSeen = 0
         )
     )
     override val theme: Flow<ThemeSelections>
@@ -74,6 +75,9 @@ class FakeUserPreferencesRepository : UserPreferencesRepository {
         }
     override val metronomeSettings: Flow<MetronomeSettings>
         get() = _preferences.map { it.metronomeSettings }
+
+    override val idOfLastAnnouncementSeen: Flow<Int>
+        get() = _preferences.map { it.idOfLastAnnouncementSeen }
 
     override suspend fun updateTheme(theme: ThemeSelections) {
         _preferences.update {
@@ -129,6 +133,12 @@ class FakeUserPreferencesRepository : UserPreferencesRepository {
     override suspend fun updateMetronomeSettings(settings: MetronomeSettings) {
         _preferences.update {
             it.copy(metronomeSettings = settings)
+        }
+    }
+
+    override suspend fun updateIdOfLastAnnouncementSeen(id: Int) {
+        _preferences.update {
+            it.copy(idOfLastAnnouncementSeen = id)
         }
     }
 }

--- a/app/src/main/java/app/musikus/core/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/app/musikus/core/data/UserPreferencesRepository.kt
@@ -49,6 +49,9 @@ object PreferenceKeys {
     val METRONOME_BPM = intPreferencesKey("metronome_bpm")
     val METRONOME_BEATS_PER_BAR = intPreferencesKey("metronome_beats_per_bar")
     val METRONOME_CLICKS_PER_BEAT = intPreferencesKey("metronome_clicks_per_beat")
+
+    // Contains the id of the last announcement message that was shown to the user
+    val LAST_ANNOUNCEMENT_SEEN = intPreferencesKey("last_announcement_seen")
 }
 
 class UserPreferencesRepositoryImpl(
@@ -89,7 +92,9 @@ class UserPreferencesRepositoryImpl(
                     ?: MetronomeSettings.Companion.DEFAULT.beatsPerBar,
                 clicksPerBeat = preferences[PreferenceKeys.METRONOME_CLICKS_PER_BEAT]
                     ?: MetronomeSettings.Companion.DEFAULT.clicksPerBeat
-            )
+            ),
+
+            idOfLastAnnouncementSeen = preferences[PreferenceKeys.LAST_ANNOUNCEMENT_SEEN] ?: -1
         )
     }
 
@@ -127,6 +132,10 @@ class UserPreferencesRepositoryImpl(
 
     override val metronomeSettings: Flow<MetronomeSettings> = userPreferences.map { preferences ->
         preferences.metronomeSettings
+    }
+
+    override val idOfLastAnnouncementSeen: Flow<Int> = userPreferences.map { preferences ->
+        preferences.idOfLastAnnouncementSeen
     }
 
     /** Mutators */
@@ -178,6 +187,12 @@ class UserPreferencesRepositoryImpl(
             preferences[PreferenceKeys.METRONOME_BPM] = settings.bpm
             preferences[PreferenceKeys.METRONOME_BEATS_PER_BAR] = settings.beatsPerBar
             preferences[PreferenceKeys.METRONOME_CLICKS_PER_BEAT] = settings.clicksPerBeat
+        }
+    }
+
+    override suspend fun updateIdOfLastAnnouncementSeen(id: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferenceKeys.LAST_ANNOUNCEMENT_SEEN] = id
         }
     }
 }

--- a/app/src/main/java/app/musikus/core/di/CoreUseCasesModule.kt
+++ b/app/src/main/java/app/musikus/core/di/CoreUseCasesModule.kt
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2024 Matthias Emde
+ */
+
+package app.musikus.core.di
+
+import app.musikus.core.domain.UserPreferencesRepository
+import app.musikus.core.domain.usecase.ConfirmAnnouncementMessageUseCase
+import app.musikus.core.domain.usecase.CoreUseCases
+import app.musikus.core.domain.usecase.GetIdOfLastSeenAnnouncementSeenUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoreUseCasesModule {
+
+    @Provides
+    @Singleton
+    fun provideCoreUseCases(
+        userPreferencesRepository: UserPreferencesRepository,
+    ): CoreUseCases {
+        return CoreUseCases(
+            getIdOfLastSeenAnnouncementSeen = GetIdOfLastSeenAnnouncementSeenUseCase(
+                userPreferencesRepository
+            ),
+            confirmAnnouncementMessage = ConfirmAnnouncementMessageUseCase(
+                userPreferencesRepository
+            ),
+        )
+    }
+}

--- a/app/src/main/java/app/musikus/core/di/CoreUseCasesModule.kt
+++ b/app/src/main/java/app/musikus/core/di/CoreUseCasesModule.kt
@@ -12,6 +12,7 @@ import app.musikus.core.domain.UserPreferencesRepository
 import app.musikus.core.domain.usecase.ConfirmAnnouncementMessageUseCase
 import app.musikus.core.domain.usecase.CoreUseCases
 import app.musikus.core.domain.usecase.GetIdOfLastSeenAnnouncementSeenUseCase
+import app.musikus.core.domain.usecase.ResetAnnouncementMessageUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,6 +35,9 @@ object CoreUseCasesModule {
             confirmAnnouncementMessage = ConfirmAnnouncementMessageUseCase(
                 userPreferencesRepository
             ),
+            resetAnnouncementMessage = ResetAnnouncementMessageUseCase(
+                userPreferencesRepository
+            )
         )
     }
 }

--- a/app/src/main/java/app/musikus/core/domain/Types.kt
+++ b/app/src/main/java/app/musikus/core/domain/Types.kt
@@ -41,7 +41,10 @@ data class UserPreferences(
     val showPausedGoals: Boolean,
 
     // Metronome
-    val metronomeSettings: MetronomeSettings
+    val metronomeSettings: MetronomeSettings,
+
+    // Announcement message
+    val idOfLastAnnouncementSeen: Int
 )
 
 interface UserPreferencesRepository {
@@ -54,6 +57,8 @@ interface UserPreferencesRepository {
     val goalSortInfo: Flow<GoalSortInfo>
 
     val metronomeSettings: Flow<MetronomeSettings>
+
+    val idOfLastAnnouncementSeen: Flow<Int>
 
     /** Mutators */
     suspend fun updateTheme(theme: ThemeSelections)
@@ -68,4 +73,6 @@ interface UserPreferencesRepository {
     suspend fun updateAppIntroDone(value: Boolean)
 
     suspend fun updateMetronomeSettings(settings: MetronomeSettings)
+
+    suspend fun updateIdOfLastAnnouncementSeen(id: Int)
 }

--- a/app/src/main/java/app/musikus/core/domain/usecase/ConfirmAnnouncementMessageUseCase.kt
+++ b/app/src/main/java/app/musikus/core/domain/usecase/ConfirmAnnouncementMessageUseCase.kt
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2024 Matthias Emde
+ */
+
+package app.musikus.core.domain.usecase
+
+import app.musikus.core.domain.UserPreferencesRepository
+import app.musikus.core.presentation.CURRENT_ANNOUNCEMENT_ID
+
+class ConfirmAnnouncementMessageUseCase(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+
+    suspend operator fun invoke() {
+        userPreferencesRepository.updateIdOfLastAnnouncementSeen(CURRENT_ANNOUNCEMENT_ID)
+    }
+}

--- a/app/src/main/java/app/musikus/core/domain/usecase/CoreUseCases.kt
+++ b/app/src/main/java/app/musikus/core/domain/usecase/CoreUseCases.kt
@@ -11,4 +11,5 @@ package app.musikus.core.domain.usecase
 data class CoreUseCases(
     val getIdOfLastSeenAnnouncementSeen: GetIdOfLastSeenAnnouncementSeenUseCase,
     val confirmAnnouncementMessage: ConfirmAnnouncementMessageUseCase,
+    val resetAnnouncementMessage: ResetAnnouncementMessageUseCase
 )

--- a/app/src/main/java/app/musikus/core/domain/usecase/CoreUseCases.kt
+++ b/app/src/main/java/app/musikus/core/domain/usecase/CoreUseCases.kt
@@ -1,0 +1,14 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2024 Matthias Emde
+ */
+
+package app.musikus.core.domain.usecase
+
+data class CoreUseCases(
+    val getIdOfLastSeenAnnouncementSeen: GetIdOfLastSeenAnnouncementSeenUseCase,
+    val confirmAnnouncementMessage: ConfirmAnnouncementMessageUseCase,
+)

--- a/app/src/main/java/app/musikus/core/domain/usecase/GetIdOfLastSeenAnnouncementSeenUseCase.kt
+++ b/app/src/main/java/app/musikus/core/domain/usecase/GetIdOfLastSeenAnnouncementSeenUseCase.kt
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2024 Matthias Emde
+ */
+
+package app.musikus.core.domain.usecase
+
+import app.musikus.core.domain.UserPreferencesRepository
+
+class GetIdOfLastSeenAnnouncementSeenUseCase(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+
+    operator fun invoke() = userPreferencesRepository.idOfLastAnnouncementSeen
+}

--- a/app/src/main/java/app/musikus/core/domain/usecase/ResetAnnouncementMessageUseCase.kt
+++ b/app/src/main/java/app/musikus/core/domain/usecase/ResetAnnouncementMessageUseCase.kt
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2025 Matthias Emde
+ */
+
+package app.musikus.core.domain.usecase
+
+import app.musikus.core.domain.UserPreferencesRepository
+import app.musikus.core.presentation.CURRENT_ANNOUNCEMENT_ID
+
+class ResetAnnouncementMessageUseCase(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+
+    suspend operator fun invoke() {
+        userPreferencesRepository.updateIdOfLastAnnouncementSeen(CURRENT_ANNOUNCEMENT_ID - 1)
+    }
+}

--- a/app/src/main/java/app/musikus/core/presentation/MainScreen.kt
+++ b/app/src/main/java/app/musikus/core/presentation/MainScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -50,8 +51,12 @@ import app.musikus.core.domain.TimeProvider
 import app.musikus.core.presentation.components.DialogActions
 import app.musikus.core.presentation.components.MainMenu
 import app.musikus.core.presentation.components.fadingEdge
+import app.musikus.core.presentation.theme.MusikusColorSchemeProvider
+import app.musikus.core.presentation.theme.MusikusPreviewElement1
 import app.musikus.core.presentation.theme.MusikusTheme
+import app.musikus.core.presentation.theme.MusikusThemedPreview
 import app.musikus.core.presentation.theme.spacing
+import app.musikus.menu.domain.ColorSchemeSelections
 import kotlinx.coroutines.launch
 
 @Composable
@@ -177,12 +182,12 @@ fun AnnouncementDialog(
                 val scrollState = rememberScrollState()
                 Column(
                     modifier = Modifier
-                        .padding(horizontal = MaterialTheme.spacing.medium)
+                        .padding(horizontal = MaterialTheme.spacing.large)
                         .fadingEdge(scrollState)
                         .verticalScroll(scrollState)
                         .weight(1f, fill = false)
                 ) {
-                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.large))
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.extraLarge))
 
                     // Heading 1
                     Text(
@@ -190,7 +195,7 @@ fun AnnouncementDialog(
                         text = stringResource(id = R.string.core_announcement_heading_1)
                     )
 
-                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
 
                     // Paragraph 1
                     Text(text = stringResource(id = R.string.core_announcement_paragraph_1))
@@ -238,5 +243,15 @@ fun AnnouncementDialog(
                 )
             }
         }
+    }
+}
+
+@MusikusPreviewElement1
+@Composable
+private fun PreviewAnnouncementDialog(
+    @PreviewParameter(MusikusColorSchemeProvider::class) theme: ColorSchemeSelections
+) {
+    MusikusThemedPreview(theme) {
+        AnnouncementDialog(onDismissRequest = {})
     }
 }

--- a/app/src/main/java/app/musikus/core/presentation/MainScreen.kt
+++ b/app/src/main/java/app/musikus/core/presentation/MainScreen.kt
@@ -8,13 +8,24 @@
 
 package app.musikus.core.presentation
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,6 +34,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -31,9 +45,13 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import app.musikus.R
 import app.musikus.core.domain.TimeProvider
+import app.musikus.core.presentation.components.DialogActions
 import app.musikus.core.presentation.components.MainMenu
+import app.musikus.core.presentation.components.fadingEdge
 import app.musikus.core.presentation.theme.MusikusTheme
+import app.musikus.core.presentation.theme.spacing
 import kotlinx.coroutines.launch
 
 @Composable
@@ -47,8 +65,9 @@ fun MainScreen(
 
     // This line ensures, that the app is only drawn when the proper theme is loaded
     // TODO: make sure this is the right way to do it
-    val theme = uiState.activeTheme ?: return
-    val colorScheme = uiState.activeColorScheme ?: return
+    val themeUiState = uiState.themeUiState
+    val theme = themeUiState.activeTheme ?: return
+    val colorScheme = themeUiState.activeColorScheme ?: return
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute by remember {
@@ -128,6 +147,94 @@ fun MainScreen(
                     timeProvider = timeProvider,
                     isMainMenuOpen = drawerState.isOpen,
                     closeMainMenu = { scope.launch { drawerState.close() } }
+                )
+            }
+        }
+
+        // Announcement dialog
+        if (uiState.showAnnouncement) {
+            AnnouncementDialog(
+                onDismissRequest = { eventHandler(MainUiEvent.DismissAnnouncement) }
+            )
+        }
+    }
+}
+
+@Composable
+fun AnnouncementDialog(
+    onDismissRequest: () -> Unit,
+) {
+    BoxWithConstraints {
+        Dialog(
+            onDismissRequest = onDismissRequest
+        ) {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = this.maxHeight * 0.68f)
+                    .clip(MaterialTheme.shapes.extraLarge)
+                    .background(MaterialTheme.colorScheme.surface)
+            ) {
+                val scrollState = rememberScrollState()
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = MaterialTheme.spacing.medium)
+                        .fadingEdge(scrollState)
+                        .verticalScroll(scrollState)
+                        .weight(1f, fill = false)
+                ) {
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.large))
+
+                    // Heading 1
+                    Text(
+                        style = MaterialTheme.typography.headlineMedium,
+                        text = stringResource(id = R.string.core_announcement_heading_1)
+                    )
+
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+
+                    // Paragraph 1
+                    Text(text = stringResource(id = R.string.core_announcement_paragraph_1))
+
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
+
+                    // Heading 2
+                    Text(
+                        style = MaterialTheme.typography.titleLarge,
+                        text = stringResource(id = R.string.core_announcement_heading_2)
+                    )
+
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+
+                    // Paragraph 2
+                    Text(text = stringResource(id = R.string.core_announcement_paragraph_2))
+
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.medium))
+
+                    // Heading 3
+                    Text(
+                        style = MaterialTheme.typography.titleLarge,
+                        text = stringResource(id = R.string.core_announcement_heading_3)
+                    )
+
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+
+                    // Paragraph 3
+                    Text(text = stringResource(id = R.string.core_announcement_paragraph_3))
+
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+
+                    // Paragraph 4
+                    Text(text = stringResource(id = R.string.core_announcement_paragraph_4))
+
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+
+                    // Paragraph 5
+                    Text(text = stringResource(id = R.string.core_announcement_paragraph_5))
+                }
+
+                DialogActions(
+                    confirmButtonText = stringResource(id = R.string.core_announcement_confirm),
+                    onConfirmHandler = onDismissRequest,
                 )
             }
         }

--- a/app/src/main/java/app/musikus/core/presentation/MainScreen.kt
+++ b/app/src/main/java/app/musikus/core/presentation/MainScreen.kt
@@ -8,13 +8,10 @@
 
 package app.musikus.core.presentation
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -25,6 +22,7 @@ import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
@@ -34,10 +32,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -169,16 +168,15 @@ fun MainScreen(
 fun AnnouncementDialog(
     onDismissRequest: () -> Unit,
 ) {
-    BoxWithConstraints {
-        Dialog(
-            onDismissRequest = onDismissRequest
+    Dialog(
+        properties = DialogProperties(dismissOnClickOutside = false),
+        onDismissRequest = onDismissRequest
+    ) {
+        Surface(
+            modifier = Modifier.padding(vertical = 64.dp),
+            shape = MaterialTheme.shapes.extraLarge
         ) {
-            Column(
-                modifier = Modifier
-                    .heightIn(max = this.maxHeight * 0.68f)
-                    .clip(MaterialTheme.shapes.extraLarge)
-                    .background(MaterialTheme.colorScheme.surface)
-            ) {
+            Column {
                 val scrollState = rememberScrollState()
                 Column(
                     modifier = Modifier

--- a/app/src/main/java/app/musikus/core/presentation/Musikus.kt
+++ b/app/src/main/java/app/musikus/core/presentation/Musikus.kt
@@ -9,36 +9,18 @@
 package app.musikus.core.presentation
 
 import android.app.Application
-import android.content.Context
-import app.musikus.R
 import dagger.hilt.android.HiltAndroidApp
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+
+const val CURRENT_ANNOUNCEMENT_ID = 1
 
 @HiltAndroidApp
 class Musikus : Application() {
-
-    override fun onCreate() {
-        super.onCreate()
-    }
-
     companion object {
-        val executorService: ExecutorService = Executors.newFixedThreadPool(4)
         private val IO_EXECUTOR = Executors.newSingleThreadExecutor()
 
         fun ioThread(f: () -> Unit) {
             IO_EXECUTOR.execute(f)
-        }
-
-        var noSessionsYet = true
-        var serviceIsRunning = false
-
-        fun getRandomQuote(context: Context): CharSequence {
-            return context.resources.getTextArray(R.array.quotes).random()
-        }
-
-        fun dp(context: Context, dp: Int): Float {
-            return context.resources.displayMetrics.density * dp
         }
     }
 }

--- a/app/src/main/java/app/musikus/core/presentation/Screen.kt
+++ b/app/src/main/java/app/musikus/core/presentation/Screen.kt
@@ -13,10 +13,10 @@ import android.os.Bundle
 import androidx.annotation.DrawableRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Help
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.CloudUpload
 import androidx.compose.material.icons.outlined.Favorite
-import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material.icons.outlined.Settings
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavType
 import androidx.navigation.toRoute
@@ -247,11 +247,11 @@ fun Screen.MainMenuEntry.getDisplayData(): DisplayData {
     return when (this) {
         is Screen.MainMenuEntry.Settings -> DisplayData(
             title = UiText.StringResource(R.string.components_main_menu_item_settings),
-            icon = UiIcon.DynamicIcon(Icons.Outlined.Settings),
+            icon = UiIcon.DynamicIcon(Icons.Filled.Settings),
         )
         is Screen.MainMenuEntry.About -> DisplayData(
             title = UiText.StringResource(R.string.components_main_menu_item_about),
-            icon = UiIcon.DynamicIcon(Icons.Outlined.Info),
+            icon = UiIcon.DynamicIcon(Icons.Filled.Info),
         )
         is Screen.MainMenuEntry.Help -> DisplayData(
             title = UiText.StringResource(R.string.components_main_menu_item_help),

--- a/app/src/main/java/app/musikus/core/presentation/components/DialogActions.kt
+++ b/app/src/main/java/app/musikus/core/presentation/components/DialogActions.kt
@@ -33,7 +33,7 @@ import app.musikus.menu.domain.ColorSchemeSelections
 
 @Composable
 fun DialogActions(
-    onDismissHandler: () -> Unit,
+    onDismissHandler: (() -> Unit)? = null,
     onConfirmHandler: () -> Unit,
     confirmButtonText: String = stringResource(id = android.R.string.ok),
     dismissButtonText: String = stringResource(id = android.R.string.cancel),
@@ -45,18 +45,20 @@ fun DialogActions(
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.End
     ) {
-        TextButton(
-            modifier = Modifier.semantics {
-                contentDescription = dismissButtonText
-            },
-            onClick = onDismissHandler,
-            colors = ButtonDefaults.textButtonColors(
-                contentColor = MaterialTheme.colorScheme.primary
-            )
-        ) {
-            Text(text = dismissButtonText)
+        if (onDismissHandler != null) {
+            TextButton(
+                modifier = Modifier.semantics {
+                    contentDescription = dismissButtonText
+                },
+                onClick = onDismissHandler,
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Text(text = dismissButtonText)
+            }
+            Spacer(modifier = Modifier.width(MaterialTheme.spacing.small))
         }
-        Spacer(modifier = Modifier.width(MaterialTheme.spacing.small))
         Button(
             modifier = Modifier.semantics {
                 contentDescription = confirmButtonText

--- a/app/src/main/java/app/musikus/core/presentation/utils/UiText.kt
+++ b/app/src/main/java/app/musikus/core/presentation/utils/UiText.kt
@@ -8,6 +8,7 @@
 
 package app.musikus.core.presentation.utils
 
+import android.text.style.RelativeSizeSpan
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
@@ -18,6 +19,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.em
 import androidx.core.text.HtmlCompat
 
 // source: https://www.youtube.com/watch?v=mB1Lej0aDus (Phillip Lackner)
@@ -92,6 +94,13 @@ fun htmlResource(@StringRes resId: Int, vararg formatArgs: Any): AnnotatedString
                 }
                 is android.text.style.UnderlineSpan -> {
                     addStyle(SpanStyle(textDecoration = TextDecoration.Underline), start, end)
+                }
+                is RelativeSizeSpan -> {
+                    addStyle(
+                        SpanStyle(fontSize = span.sizeChange.em),
+                        start,
+                        end
+                    )
                 }
             }
         }

--- a/app/src/main/java/app/musikus/menu/presentation/help/HelpScreen.kt
+++ b/app/src/main/java/app/musikus/menu/presentation/help/HelpScreen.kt
@@ -9,7 +9,9 @@
 package app.musikus.menu.presentation.help
 
 import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -27,19 +29,50 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import app.musikus.R
+import app.musikus.core.domain.usecase.CoreUseCases
 import app.musikus.core.presentation.MusikusTopBar
 import app.musikus.core.presentation.theme.spacing
 import app.musikus.core.presentation.utils.UiText
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed class HelpUiEvent {
+    object ShowAnnouncementDialog : HelpUiEvent()
+}
+
+typealias HelpUiEventHandler = (HelpUiEvent) -> Boolean
+
+@HiltViewModel
+class HelpViewModel @Inject constructor(
+    private val coreUseCases: CoreUseCases
+) : ViewModel() {
+    fun onUiEvent(event: HelpUiEvent) : Boolean {
+        when (event) {
+            HelpUiEvent.ShowAnnouncementDialog -> viewModelScope.launch {
+                coreUseCases.resetAnnouncementMessage()
+            }
+        }
+
+        return true
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HelpScreen(
+    viewModel: HelpViewModel = hiltViewModel(),
     navigateUp: () -> Unit
 ) {
     val context = LocalContext.current
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
+    val eventHandler = viewModel::onUiEvent
 
     Scaffold(
         topBar = {
@@ -54,6 +87,17 @@ fun HelpScreen(
         Column(
             modifier = Modifier.padding(paddingValues)
         ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(MaterialTheme.spacing.medium),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Button(onClick = { eventHandler(HelpUiEvent.ShowAnnouncementDialog) }) {
+                    Text("Show Announcement Dialog")
+                }
+            }
+            HorizontalDivider(Modifier.padding(vertical = MaterialTheme.spacing.medium))
             Column(
                 modifier = Modifier.padding(horizontal = MaterialTheme.spacing.large)
             ) {

--- a/app/src/main/java/app/musikus/menu/presentation/help/HelpScreen.kt
+++ b/app/src/main/java/app/musikus/menu/presentation/help/HelpScreen.kt
@@ -94,7 +94,7 @@ fun HelpScreen(
                 horizontalArrangement = Arrangement.Center
             ) {
                 Button(onClick = { eventHandler(HelpUiEvent.ShowAnnouncementDialog) }) {
-                    Text("Show Announcement Dialog")
+                    Text(stringResource(R.string.menu_help_show_announcement))
                 }
             }
             HorizontalDivider(Modifier.padding(vertical = MaterialTheme.spacing.medium))

--- a/app/src/main/res/values/menu_strings.xml
+++ b/app/src/main/res/values/menu_strings.xml
@@ -60,6 +60,7 @@
 
     <!-- Help -->
     <string name="menu_help_title">Help</string>
+    <string name="menu_help_show_announcement">Show last Announcement</string>
     <string name="menu_help_tips_title">Tips and tricks</string>
     <string name="menu_help_tips_text">Have you tried…</string>
     <string-array name="menu_help_tips_bulletlist">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
 
     <string name="core_announcement_confirm">Awesome!</string>
     <string name="core_announcement_heading_1">Welcome to Musikus!</string>
-    <string name="core_announcement_paragraph_1">Thank you for joining the open beta of Musikus! We\'re thrilled to have you on this journey as we shape the future of music practice.</string>
+    <string name="core_announcement_paragraph_1">Thank you for joining the open beta of Musikus! We\'re thrilled to have you on this journey with us.</string>
     <string name="core_announcement_heading_2">A Work in Progress</string>
     <string name="core_announcement_paragraph_2">As an open beta, Musikus is still in development, and you may encounter some bugs or incomplete features. Your feedback is invaluable in helping us refine the experience, so please don\'t hesitate to share your thoughts with us!</string>
     <string name="core_announcement_heading_3">A Legacy Continued</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,15 @@
     <string name="core_average_sign" translatable="false">Ø</string>
     <string name="core_star_sign" translatable="false">★</string>
 
+    <string name="core_announcement_confirm">Awesome!</string>
+    <string name="core_announcement_heading_1">Welcome to Musikus!</string>
+    <string name="core_announcement_paragraph_1">Thank you for joining the open beta of Musikus! We\'re thrilled to have you on this journey as we shape the future of music practice.</string>
+    <string name="core_announcement_heading_2">A Work in Progress</string>
+    <string name="core_announcement_paragraph_2">As an open beta, Musikus is still in development, and you may encounter some bugs or incomplete features. Your feedback is invaluable in helping us refine the experience, so please don\'t hesitate to share your thoughts with us!</string>
+    <string name="core_announcement_heading_3">A Legacy Continued</string>
+    <string name="core_announcement_paragraph_3">If you\'re a fan of PracticeTime, you\'ll feel right at home here. Musikus is the next evolution of that app, built by the same developers, with new tools and features to elevate your practice sessions.</string>
+    <string name="core_announcement_paragraph_4">Thank you for being a part of our beta community. Together, we can make Musikus a fantastic resource for musicians everywhere!</string>
+    <string name="core_announcement_paragraph_5">Happy practicing!</string>
 
     <!-- Components -->
 

--- a/app/src/test/java/app/musikus/core/data/FakeUserPreferencesRepository.kt
+++ b/app/src/test/java/app/musikus/core/data/FakeUserPreferencesRepository.kt
@@ -40,7 +40,8 @@ class FakeUserPreferencesRepository : UserPreferencesRepository {
             goalsSortMode = GoalsSortMode.Companion.DEFAULT,
             goalsSortDirection = SortDirection.Companion.DEFAULT,
             showPausedGoals = true,
-            metronomeSettings = MetronomeSettings.Companion.DEFAULT
+            metronomeSettings = MetronomeSettings.Companion.DEFAULT,
+            idOfLastAnnouncementSeen = 0
         )
     )
     override val theme: Flow<ThemeSelections>
@@ -74,6 +75,9 @@ class FakeUserPreferencesRepository : UserPreferencesRepository {
         }
     override val metronomeSettings: Flow<MetronomeSettings>
         get() = _preferences.map { it.metronomeSettings }
+
+    override val idOfLastAnnouncementSeen: Flow<Int>
+        get() = _preferences.map { it.idOfLastAnnouncementSeen }
 
     override suspend fun updateTheme(theme: ThemeSelections) {
         _preferences.update {
@@ -129,6 +133,12 @@ class FakeUserPreferencesRepository : UserPreferencesRepository {
     override suspend fun updateMetronomeSettings(settings: MetronomeSettings) {
         _preferences.update {
             it.copy(metronomeSettings = settings)
+        }
+    }
+
+    override suspend fun updateIdOfLastAnnouncementSeen(id: Int) {
+        _preferences.update {
+            it.copy(idOfLastAnnouncementSeen = id)
         }
     }
 }


### PR DESCRIPTION
This PR adds an announcement dialog which is shown the first time the user starts the app.
On every update we have the option to increase the value in `CURRENT_ANNOUNCEMENT_ID` to trigger the dialogue again.

![announcement](https://github.com/user-attachments/assets/38e6354c-1a28-487e-aca0-f039cfebf679)

I'm not 100% happy with how the dialogue looks. Atm it uses `htmlResource` so we only have to change out the string resource but can still include some styling...

Fixes: #140 