### PR TITLE
fix: replace content padding in lists by spacers

### DIFF
--- a/app/src/main/java/app/musikus/goals/presentation/GoalsScreen.kt
+++ b/app/src/main/java/app/musikus/goals/presentation/GoalsScreen.kt
@@ -19,9 +19,11 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -178,17 +180,25 @@ fun GoalsScreen(
         content = { paddingValues ->
             val contentUiState = uiState.contentUiState
 
+            val verticalArrangementSpacing = MaterialTheme.spacing.medium
+
             // Goal List
             LazyColumn(
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(
                     start = MaterialTheme.spacing.large,
                     end = MaterialTheme.spacing.large,
-                    top = paddingValues.calculateTopPadding() + 16.dp,
-                    bottom = paddingValues.calculateBottomPadding() + 56.dp,
+                    top = paddingValues.calculateTopPadding(),
+                    bottom = paddingValues.calculateBottomPadding(),
                 ),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(verticalArrangementSpacing),
             ) {
+                // header and footer spacers replace contentPadding
+                // but also serve to anchor the column when inserting items
+                item {
+                    Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+                }
+
                 items(
                     items = contentUiState.currentGoals,
                     key = { it.instance.id },
@@ -219,6 +229,11 @@ fun GoalsScreen(
                             timeProvider = timeProvider
                         )
                     }
+                }
+
+                // extra large spacer as footer for clearing the fab button
+                item {
+                    Spacer(modifier = Modifier.height(56.dp - verticalArrangementSpacing))
                 }
             }
 

--- a/app/src/main/java/app/musikus/library/presentation/LibraryScreen.kt
+++ b/app/src/main/java/app/musikus/library/presentation/LibraryScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -214,12 +215,18 @@ fun LibraryContent(
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(
-            top = contentPadding.calculateTopPadding() + 16.dp,
-            bottom = contentPadding.calculateBottomPadding() + 56.dp,
+            top = contentPadding.calculateTopPadding(),
+            bottom = contentPadding.calculateBottomPadding(),
         ),
     ) {
         val foldersUiState = contentUiState.foldersUiState
         val itemsUiState = contentUiState.itemsUiState
+
+        // header and footer items replace contentPadding
+        // but also serve to anchor the column when inserting items
+        item {
+            Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+        }
 
         /** Folders */
         if (foldersUiState != null) {
@@ -261,11 +268,12 @@ fun LibraryContent(
                 LazyRow(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    // header and footer items replace contentPadding
-                    // but also serve to fixate the list when inserting items
+                    // start and end spacers replace contentPadding
+                    // but also serve to anchor the row when inserting items
                     item {
                         Spacer(modifier = Modifier.width(MaterialTheme.spacing.small))
                     }
+
                     items(
                         items = foldersUiState.foldersWithItems,
                         key = { it.folder.id }
@@ -287,10 +295,17 @@ fun LibraryContent(
                             )
                         }
                     }
+
+                    // small spacer at the end of the row
                     item {
                         Spacer(modifier = Modifier.width(MaterialTheme.spacing.small))
                     }
                 }
+            }
+
+            // small spacer between folders and items
+            item {
+                Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
             }
         }
 
@@ -300,6 +315,11 @@ fun LibraryContent(
                 uiState = itemsUiState,
                 libraryCoreEventHandler = { eventHandler(LibraryUiEvent.CoreUiEvent(it)) },
             )
+        }
+
+        // extra large spacer as footer for clearing the fab button
+        item {
+            Spacer(modifier = Modifier.height(56.dp))
         }
     }
 }

--- a/app/src/main/java/app/musikus/library/presentation/libraryfolder/LibraryFolderDetailsScreen.kt
+++ b/app/src/main/java/app/musikus/library/presentation/libraryfolder/LibraryFolderDetailsScreen.kt
@@ -3,14 +3,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2024 Matthias Emde
+ * Copyright (c) 2024-2025 Matthias Emde
  */
 
 package app.musikus.library.presentation.libraryfolder
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -19,6 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -36,6 +39,7 @@ import app.musikus.core.presentation.MainUiEventHandler
 import app.musikus.core.presentation.MusikusTopBar
 import app.musikus.core.presentation.components.ActionBar
 import app.musikus.core.presentation.components.SortMenu
+import app.musikus.core.presentation.theme.spacing
 import app.musikus.library.data.LibraryItemSortMode
 import app.musikus.library.presentation.LibraryCoreUiEvent
 import app.musikus.library.presentation.LibraryDialogs
@@ -148,19 +152,29 @@ fun LibraryFolderDetailsScreen(
         LazyColumn(
             modifier = Modifier.fillMaxWidth(),
             contentPadding = PaddingValues(
-                top = paddingValues.calculateTopPadding() + 16.dp,
-                bottom = paddingValues.calculateBottomPadding() + 56.dp,
+                top = paddingValues.calculateTopPadding(),
+                bottom = paddingValues.calculateBottomPadding(),
             ),
         ) {
-            val itemsUiState = uiState.itemsUiState
+            // header and footer spacers replace contentPadding
+            // but also serve to anchor the column when inserting items
+            item {
+                Spacer(modifier = Modifier.height(MaterialTheme.spacing.small))
+            }
 
             /** Items */
+            val itemsUiState = uiState.itemsUiState
             if (itemsUiState != null) {
                 libraryItemsComponent(
                     uiState = itemsUiState,
                     libraryCoreEventHandler = { eventHandler(LibraryFolderDetailsUiEvent.CoreUiEvent(it)) },
                     showHeader = false
                 )
+            }
+
+            // extra large spacer as footer for clearing the fab button
+            item {
+                Spacer(modifier = Modifier.height(56.dp))
             }
         }
 

--- a/app/src/main/java/app/musikus/sessions/presentation/SessionsScreen.kt
+++ b/app/src/main/java/app/musikus/sessions/presentation/SessionsScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -34,6 +36,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -60,7 +63,9 @@ import app.musikus.core.presentation.theme.spacing
 import app.musikus.core.presentation.utils.DurationString
 import app.musikus.core.presentation.utils.UiIcon
 import app.musikus.core.presentation.utils.UiText
+import kotlinx.coroutines.delay
 import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(
     ExperimentalMaterial3Api::class,
@@ -88,6 +93,16 @@ fun SessionsScreen(
     val fabExpanded by remember {
         derivedStateOf {
             sessionsListState.firstVisibleItemIndex == 0
+        }
+    }
+
+    /**
+     * When a session is finished, scroll to the top
+     */
+    LaunchedEffect(mainUiState.isSessionRunning) {
+        if (!mainUiState.isSessionRunning) {
+            delay(300.milliseconds)
+            sessionsListState.animateScrollToItem(0)
         }
     }
 
@@ -165,8 +180,8 @@ fun SessionsScreen(
                 contentPadding = PaddingValues(
                     start = MaterialTheme.spacing.large,
                     end = MaterialTheme.spacing.large,
-                    top = paddingValues.calculateTopPadding() + 16.dp,
-                    bottom = paddingValues.calculateBottomPadding() + 56.dp,
+                    top = paddingValues.calculateTopPadding(),
+                    bottom = paddingValues.calculateBottomPadding(),
                 ),
                 state = sessionsListState,
             ) {
@@ -220,6 +235,11 @@ fun SessionsScreen(
                             }
                         }
                     }
+                }
+
+                // extra large spacer as footer for clearing the fab button
+                item {
+                    Spacer(modifier = Modifier.height(56.dp))
                 }
             }
 


### PR DESCRIPTION
These spacers also serve the purpose of anchoring the elements when adding new items