### PR TITLE
fix: remove card elevation on all cards

### DIFF
--- a/app/src/main/java/app/musikus/goals/presentation/GoalCard.kt
+++ b/app/src/main/java/app/musikus/goals/presentation/GoalCard.kt
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2022-2025 Matthias Emde
+ * Copyright (c) 2022-2025 Matthias Emde, Michael Prommersberger
  */
 
 package app.musikus.goals.presentation
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.rounded.Repeat
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
@@ -76,7 +77,8 @@ fun GoalCard(
 
     ElevatedCard(
         modifier = modifier
-            .blur(if (description.paused) 1.5.dp else 0.dp)
+            .blur(if (description.paused) 1.5.dp else 0.dp),
+        elevation = CardDefaults.cardElevation(0.dp),
     ) {
         Box {
             Column(modifier = Modifier.padding(16.dp)) {

--- a/app/src/main/java/app/musikus/library/presentation/LibraryComponents.kt
+++ b/app/src/main/java/app/musikus/library/presentation/LibraryComponents.kt
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2024-2025 Matthias Emde
+ * Copyright (c) 2024-2025 Matthias Emde, Michael Prommersberger
  */
 
 package app.musikus.library.presentation
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
@@ -79,7 +80,10 @@ fun LibraryFolderComponent(
         onLongClick = onLongClick,
         shape = MaterialTheme.shapes.large,
     ) {
-        ElevatedCard(Modifier.size(150.dp)) {
+        ElevatedCard(
+            Modifier.size(150.dp),
+            elevation = CardDefaults.cardElevation(0.dp),
+        ) {
             Column(
                 modifier = Modifier
                     .padding(8.dp)

--- a/app/src/main/java/app/musikus/sessions/presentation/SessionCard.kt
+++ b/app/src/main/java/app/musikus/sessions/presentation/SessionCard.kt
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2022-2025 Matthias Emde
+ * Copyright (c) 2022-2025 Matthias Emde, Michael Prommersberger
  */
 
 package app.musikus.sessions.presentation
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -125,7 +126,9 @@ fun SessionCard(
     // used as ratio for the two columns
     val goldenRatio = 1.618f
 
-    ElevatedCard {
+    ElevatedCard(
+        elevation = CardDefaults.cardElevation(0.dp),
+    ) {
         /** Card Header */
         Row(
             modifier = Modifier

--- a/app/src/main/java/app/musikus/statistics/presentation/StatisticsScreen.kt
+++ b/app/src/main/java/app/musikus/statistics/presentation/StatisticsScreen.kt
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2023-2024 Matthias Emde
+ * Copyright (c) 2023-2025 Matthias Emde, Michael Prommersberger
  */
 
 package app.musikus.statistics.presentation
@@ -33,6 +33,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -247,7 +248,8 @@ fun StatisticsSessionsCard(
     navigateToSessionStatistics: () -> Unit,
 ) {
     ElevatedCard(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(0.dp),
     ) {
         Column(
             modifier = Modifier
@@ -381,7 +383,8 @@ fun StatisticsGoalsCard(
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
-            .wrapContentHeight()
+            .wrapContentHeight(),
+        elevation = CardDefaults.cardElevation(0.dp),
     ) {
         Column(
             modifier = Modifier
@@ -492,7 +495,10 @@ fun StatisticsGoalsCard(
 fun StatisticsRatingsCard(
     uiState: StatisticsRatingsCardUiState
 ) {
-    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(0.dp),
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
This PR sets all elevation of all `ElevatedCard` to 0dp which removes the drop shadow. Due to our wrapped `Selectable` Composable, shadows have effectively not been visible due to the `clip` in Selectable. Because Statistics cards have not been wrapped by `Selectable`, this was the only place where drop shadow was visible.

This PR unifys the appearance to ensure no drop shadow is displayed at all.