### PR TITLE
chore: avoid binary BLOBs in APK file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,6 +161,13 @@ android {
         xmlOutput = file("$reportsPath/lint/android.xml")
         textOutput = file("$reportsPath/lint/android.txt")
     }
+
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
 }
 
 room {


### PR DESCRIPTION
As @IzzySoft [pointed out](https://github.com/matthiasemde/musikus-android/issues/163#issuecomment-2604559117), Google adds an encrypted binary BLOB to the APK file when building the app. This behavior is explained very well in detail [in this article](https://android.izzysoft.de/articles/named/iod-scan-apkchecks#blobs).

Since such signing blobs may contain payload/malicious code, it is regarded as a security risk by F-droid and thus it is displayed in the "Signing Blocks" area [in our app listing](https://apt.izzysoft.de/fdroid/index/apk/app.musikus).

This PR removes this block according to the [official documentation](https://developer.android.com/build/dependencies#dependency-info-play).

AFAIK we will not really "lose" any functionality, the only thing which might be affected is how Google warns us about our used dependencies.