### PR TITLE
ci: force 7-char commit hash in release jobs

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -52,7 +52,7 @@ jobs:
           VERSION_CODE=$(date +"%y%V%u42")
           echo "version_name=${VERSION_NAME}" >> "$GITHUB_ENV"
           echo "version_code=${VERSION_CODE}" >> "$GITHUB_ENV"
-          echo "tag_name=${SEMANTIC_VERSION}" >> "$GITHUB_ENV"    
+          echo "tag_name=${SEMANTIC_VERSION}" >> "$GITHUB_ENV"
 
       - name: Decode release bot public and private signing key
         run: |
@@ -74,7 +74,7 @@ jobs:
           sed -i "
             s/versionName=.*/versionName=$version_name/
             s/versionCode=.*/versionCode=$version_code/
-          " build.properties   
+          " build.properties
 
       - name: Add release tag to remote
         run: |
@@ -133,7 +133,7 @@ jobs:
 
       - name: Write commit hash to build.properties
         run: |
-          COMMIT_HASH=$(git rev-parse --short HEAD)
+          COMMIT_HASH=$(git rev-parse --short=7 HEAD)
           sed -i "s/commitHash=.*/commitHash=$COMMIT_HASH/" build.properties
 
       - uses: actions/setup-java@v4
@@ -193,7 +193,7 @@ jobs:
 
       - name: Write commit hash to build.properties
         run: |
-          COMMIT_HASH=$(git rev-parse --short HEAD)
+          COMMIT_HASH=$(git rev-parse --short=7 HEAD)
           sed -i "s/commitHash=.*/commitHash=$COMMIT_HASH/" build.properties
 
       - uses: actions/setup-java@v4

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Write version name, version code, and commit hash to build.properties
         if: env.skip_nightly == 'false'
         run: |
-          COMMIT_HASH=$(git rev-parse --short HEAD)
+          COMMIT_HASH=$(git rev-parse --short=7 HEAD)
           sed -i -e "
             s/versionName=.*/versionName=$version_name/
             s/versionCode=.*/versionCode=$version_code/


### PR DESCRIPTION
As @IzzySoft [pointed out](https://github.com/matthiasemde/musikus-android/issues/163#issuecomment-2604559117), our CI does produce a 7-char commit hash while his CI (and also my machine) produces 8 chars. Apparently the length [is dynamic](https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortlength) and my tests under Ubuntu always produced 7 chars on our repository (CI also runs on Ubuntu) while my git client (Arch Linux) produces 8 bit.

I don't know why exactly it is this way, though since the [`core.abbrev`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev) config is not overridden.

Anyways, to mitigate this small confusion, I now fixed the length of the commit hash in our CI to 7 chars to be better compatible with other toolchains/CIs. 

Since our changelog is also based on 7-char commit hashes and 7 chars [seems to be enough](https://stackoverflow.com/a/18134919), i chose 7 over 8.