### PR TITLE
chore: fix discord webhook failing in some cases

### DIFF
--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -37,12 +37,15 @@ jobs:
       - name: Send Discord notification for Release
         if: github.event_name == 'release'
         run: |
-          BODY=$'${{ github.event.release.body }}'
+          BODY=$(cat <<'EOF'
+          ${{ github.event.release.body }}
+          EOF
+          )
           response=$(curl -s -w "%{http_code}" -H "Content-Type: application/json" \
           -X POST \
           -d "$(jq -n --arg title "${{ github.event.release.title }}" \
             --arg url "${{ github.event.release.html_url }}" \
-            --arg body "$(echo $BODY | sed 's/`/\\`/g')" \
+            --arg body "$BODY" \
             --arg tag "${{ github.event.release.tag_name }}" \
             '{"content": "🎉 **New Release**: [\($title)](\($url))\n\n📦 **Version**: \($tag)\n\n📝 **Description**: \($body)"}')" \
           ${{ secrets.DISCORD_WEBHOOK_URL }})


### PR DESCRIPTION
This PR fixes the failing discord webhook in case an apostroph is contained in the pull request body. Additionally, it fixes the broken markdown styling in Discord (headlines, code blocks).

Example of the webhook failing: #175 ([workflow run](https://github.com/matthiasemde/musikus-android/actions/runs/16465594324/job/46542059448)). 

